### PR TITLE
Create role from LDAP

### DIFF
--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -1,0 +1,52 @@
+from __future__ import unicode_literals
+
+import logging
+
+import psycopg2
+from psycopg2 import sql
+
+logger = logging.getLogger(__name__)
+
+
+class RoleManager(object):
+    def __init__(self, ldapconn, pgconn):
+        self.ldapconn = ldapconn
+        self.pgconn = pgconn
+        self.pgcursor = None
+
+    def __enter__(self):
+        self.pgcursor = self.pgconn.cursor()
+
+    def __exit__(self, *a):
+        self.pgcursor.close()
+
+    def fetch_pg_roles(self):
+        logger.debug("Querying PostgreSQL for existing roles.")
+        self.pgcursor.execute(
+            "SELECT rolname FROM pg_catalog.pg_roles WHERE rolname !~ '^pg_'",
+        )
+        payload = self.pgcursor.fetchall()
+        return {r[0] for r in payload}
+
+    def fetch_ldap_roles(self, base, query):
+        logger.debug("Querying LDAP for wanted roles.")
+        self.ldapconn.search(base, query, attributes=['*'])
+        return {r.cn.value for r in self.ldapconn.entries}
+
+    def create(self, role):
+        logger.info("Creating new role %s.", role)
+        self.pgcursor.execute(
+            sql.SQL('CREATE ROLE {name} WITH LOGIN').format(
+                name=psycopg2.sql.Identifier(role),
+            )
+        )
+        self.pgconn.commit()
+
+    def sync(self, base, query):
+        with self:
+            pgroles = self.fetch_pg_roles()
+            ldaproles = self.fetch_ldap_roles(base=base, query=query)
+            missing = ldaproles - pgroles
+            for role in missing:
+                self.create(*role)
+        logger.info("Synchronization complete.")

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -21,15 +21,16 @@ def main():
     logger.debug("Starting ldap2pg %s.", __version__)
 
     try:
-        logger.debug("Connecting to PostgreSQL from env vars.")
-        psycopg2.connect("")
-
         logger.debug("Connecting to LDAP.")
         server = ldap3.Server(os.environ['LDAP_HOST'], get_info=ldap3.ALL)
         conn = ldap3.Connection(
             server, os.environ['LDAP_BIND'], os.environ['LDAP_PASSWORD'],
             auto_bind=True,
         )
+
+        logger.debug("Connecting to PostgreSQL from env vars.")
+        psycopg2.connect(os.environ.get('PGDSN', ''))
+
         logger.debug("Searching LDAP.")
         conn.search(os.environ['LDAP_BASE'], '(objectClass=*)')
     except Exception:

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -51,5 +51,5 @@ def main():
         exit(1)
 
 
-if '__main__' == __name__:
+if '__main__' == __name__:  # pragma: no cover
     main()

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -47,7 +47,7 @@ def main():
         manager = RoleManager(ldapconn=ldapconn, pgconn=pgconn)
         manager.sync(base=ldap_base, query=ldap_query)
     except Exception:
-        logger.exception('/o\\')
+        logger.exception('Unhandled error:')
         exit(1)
 
 

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -9,35 +9,46 @@ import os
 import ldap3
 import psycopg2
 
+from .manager import RoleManager
+
 
 logger = logging.getLogger(__name__)
+
+
+def create_ldap_connection(host, bind, password):
+    logger.debug("Connecting to LDAP server %s.", host)
+    server = ldap3.Server(host, get_info=ldap3.ALL)
+    return ldap3.Connection(server, bind, password, auto_bind=True)
+
+
+def create_pg_connection(dsn):
+    logger.debug("Connecting to PostgreSQL.")
+    return psycopg2.connect(dsn)
 
 
 def main():
     logging.basicConfig(
         level=logging.DEBUG,
-        format='%(levelname).5s %(message)s'
+        format='%(levelname)5.5s %(message)s'
     )
     logger.debug("Starting ldap2pg %s.", __version__)
 
     try:
-        logger.debug("Connecting to LDAP.")
-        server = ldap3.Server(os.environ['LDAP_HOST'], get_info=ldap3.ALL)
-        conn = ldap3.Connection(
-            server, os.environ['LDAP_BIND'], os.environ['LDAP_PASSWORD'],
-            auto_bind=True,
+        ldapconn = create_ldap_connection(
+            host=os.environ['LDAP_HOST'],
+            bind=os.environ['LDAP_BIND'],
+            password=os.environ['LDAP_PASSWORD'],
         )
+        pgconn = create_pg_connection(dsn=os.environ.get('PGDSN', ''))
 
-        logger.debug("Connecting to PostgreSQL from env vars.")
-        psycopg2.connect(os.environ.get('PGDSN', ''))
+        ldap_base = os.environ['LDAP_BASE']
+        ldap_query = '(objectClass=organizationalRole)'
 
-        logger.debug("Searching LDAP.")
-        conn.search(os.environ['LDAP_BASE'], '(objectClass=*)')
+        manager = RoleManager(ldapconn=ldapconn, pgconn=pgconn)
+        manager.sync(base=ldap_base, query=ldap_query)
     except Exception:
         logger.exception('/o\\')
         exit(1)
-
-    print(r'\o/')
 
 
 if '__main__' == __name__:

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1,0 +1,62 @@
+def test_context_manager(mocker):
+    from ldap2pg.manager import RoleManager
+
+    manager = RoleManager(pgconn=mocker.Mock(), ldapconn=mocker.Mock())
+    with manager:
+        assert manager.pgcursor
+
+
+def test_fetch_existing_roles(mocker):
+    from ldap2pg.manager import RoleManager
+
+    manager = RoleManager(pgconn=mocker.Mock(), ldapconn=mocker.Mock())
+    manager.pgcursor = mocker.Mock()
+
+    manager.pgcursor.fetchall.return_value = [
+        ('alice',),
+        ('bob',),
+    ]
+    existing_roles = manager.fetch_pg_roles()
+
+    assert {'alice', 'bob'} == existing_roles
+
+
+def test_fetch_wanted_roles(mocker):
+    from ldap2pg.manager import RoleManager
+
+    manager = RoleManager(pgconn=mocker.Mock(), ldapconn=mocker.Mock())
+
+    manager.ldapconn.entries = [
+        mocker.Mock(cn=mocker.Mock(value='alice')),
+        mocker.Mock(cn=mocker.Mock(value='bob')),
+    ]
+    wanted_roles = manager.fetch_ldap_roles(
+        base='ou=people,dc=global', query='(objectClass=*)',
+    )
+
+    assert {'alice', 'bob'} == wanted_roles
+
+
+def test_create(mocker):
+    from ldap2pg.manager import RoleManager
+
+    manager = RoleManager(pgconn=mocker.Mock(), ldapconn=mocker.Mock())
+    manager.pgcursor = mocker.Mock()
+    manager.create('bob')
+
+    assert manager.pgcursor.execute.called is True
+    assert manager.pgconn.commit.called is True
+
+
+def test_sync(mocker):
+    p = mocker.patch('ldap2pg.manager.RoleManager.fetch_pg_roles')
+    l = mocker.patch('ldap2pg.manager.RoleManager.fetch_ldap_roles')
+    mocker.patch('ldap2pg.manager.RoleManager.create')
+
+    p.return_value = set()
+    l.return_value = {'alice', 'bob'}
+
+    from ldap2pg.manager import RoleManager
+
+    manager = RoleManager(pgconn=mocker.Mock(), ldapconn=mocker.Mock())
+    manager.sync(base='ou=people,dc=global', query='(objectClass=*)')

--- a/tests/unit/test_script.py
+++ b/tests/unit/test_script.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_main(mocker):
     environ = dict(
         LDAP_HOST='x',
@@ -13,6 +16,18 @@ def test_main(mocker):
     from ldap2pg.script import main
 
     main()
+
+
+def test_main_error(mocker):
+    mocker.patch('ldap2pg.script.logging.basicConfig')
+    clc = mocker.patch('ldap2pg.script.create_ldap_connection')
+
+    from ldap2pg.script import main
+
+    clc.side_effect = Exception()
+
+    with pytest.raises(SystemExit):
+        main()
 
 
 def test_create_ldap(mocker):

--- a/tests/unit/test_script.py
+++ b/tests/unit/test_script.py
@@ -7,9 +7,31 @@ def test_main(mocker):
     )
     mocker.patch('ldap2pg.script.os.environ', environ)
     mocker.patch('ldap2pg.script.logging.basicConfig')
-    mocker.patch('ldap2pg.script.psycopg2.connect')
-    mocker.patch('ldap2pg.script.ldap3.Connection')
+    mocker.patch('ldap2pg.script.create_ldap_connection')
+    mocker.patch('ldap2pg.script.create_pg_connection')
 
     from ldap2pg.script import main
 
     main()
+
+
+def test_create_ldap(mocker):
+    mocker.patch('ldap2pg.script.ldap3.Connection', autospec=True)
+    from ldap2pg.script import create_ldap_connection
+
+    conn = create_ldap_connection(
+        host='ldap.company.com',
+        bind='cn=admin,dc=company,dc=com', password='keepmesecret',
+    )
+
+    assert conn
+
+
+def test_create_pgconn(mocker):
+    mocker.patch('ldap2pg.script.psycopg2.connect', autospec=True)
+
+    from ldap2pg.script import create_pg_connection
+
+    conn = create_pg_connection(dsn="")
+
+    assert conn


### PR DESCRIPTION
This PR provides:

- Supports `PGDSN` env var as well as other `PG*` standard env vars.
- Create missing roles provided by LDAP in PostgreSQL