### PR TITLE
Implement sync map

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,14 @@ Features
 
 ::
 
+    $ cat ldap2pg.yml
+    sync_map:
+      ldap:
+        base: ou=people,dc=ldap2pg,dc=local
+        filter: "(objectClass=organizationalRole)"
+        attribute: cn
+      role:
+        name_attribute: cn
     $ ldap2pg
      INFO Starting ldap2pg 0.1.
      INFO Creating new role alice.

--- a/dev-fixture.ldif
+++ b/dev-fixture.ldif
@@ -1,14 +1,53 @@
+#
+# Dév fixture provides two UO: people and groups. Groups has a `member`
+# attribute referencing people.
+#
+
 dn: ou=people,dc=ldap2pg,dc=local
 objectclass: organizationalUnit
 objectclass: top
 ou: people
+
+dn: cn=alice,ou=people,dc=ldap2pg,dc=local
+cn: alice
+objectclass: organizationalRole
+objectclass: top
 
 dn: cn=bob,ou=people,dc=ldap2pg,dc=local
 cn: bob
 objectclass: organizationalRole
 objectclass: top
 
-dn: cn=alice,ou=people,dc=ldap2pg,dc=local
-cn: alice
+dn: cn=foo,ou=people,dc=ldap2pg,dc=local
+cn: foo
 objectclass: organizationalRole
 objectclass: top
+
+dn: cn=bar,ou=people,dc=ldap2pg,dc=local
+cn: bar
+objectclass: organizationalRole
+objectclass: top
+
+dn: ou=groups,dc=ldap2pg,dc=local
+objectclass: organizationalUnit
+objectclass: top
+ou: people
+
+dn: cn=dba,ou=groups,dc=ldap2pg,dc=local
+objectClass: groupOfNames
+objectClass: top
+cn: dba
+member: cn=alice,ou=people,dc=ldap2pg,dc=local
+member: cn=bob,ou=people,dc=ldap2pg,dc=local
+
+dn: cn=app0,ou=groups,dc=ldap2pg,dc=local
+objectClass: groupOfNames
+objectClass: top
+cn: app0
+member: cn=foo,ou=people,dc=ldap2pg,dc=local
+
+dn: cn=app1,ou=groups,dc=ldap2pg,dc=local
+objectClass: groupOfNames
+objectClass: top
+cn: app1
+member: cn=bar,ou=people,dc=ldap2pg,dc=local

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -1,0 +1,10 @@
+ldap:
+  bind: cn=admin,dc=ldap2pg,dc=local
+
+sync_map:
+- ldap:
+    base: ou=people,dc=ldap2pg,dc=local
+    filter: "(objectClass=organizationalRole)"
+    attribute: cn
+  role:
+    name_attribute: cn

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -12,7 +12,6 @@ import yaml
 from .utils import (
     deepget,
     deepset,
-    deepupdate,
 )
 
 
@@ -173,8 +172,6 @@ class Configuration(dict):
         logger.debug("Configuration loaded.")
 
     def merge(self, file_config, environ=os.environ):
-        self.update(file_config)
-
         for mapping in self.MAPPINGS:
             value = mapping.process(
                 default=deepget(self.DEFAULTS, mapping.path),
@@ -189,6 +186,3 @@ class Configuration(dict):
             raise ValueError("Configuration file must be a mapping")
         payload['world_readable'] = bool(mode & 0o044)
         return payload
-
-    def update(self, other):
-        deepupdate(self, other)

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 from fnmatch import fnmatch
 import logging
 
-import psycopg2
-
 logger = logging.getLogger(__name__)
 
 

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -41,10 +41,7 @@ def wrapped_main():
         blacklist=config['postgres']['blacklist'],
         dry=config['dry'],
     )
-    manager.sync(
-        base=config['ldap']['base'],
-        query=config['ldap']['filter'],
-    )
+    manager.sync(map_=config['sync_map'])
 
 
 def main():

--- a/ldap2pg/utils.py
+++ b/ldap2pg/utils.py
@@ -1,17 +1,3 @@
-import collections
-
-
-def deepupdate(self, other):
-    """Recursive update of two dict."""
-    for k, v in other.items():
-        if isinstance(v, collections.Mapping):
-            r = deepupdate(self.get(k, {}), v)
-            self[k] = r
-        else:
-            self[k] = other[k]
-    return self
-
-
 def deepget(mapping, path):
     """Access deep dict entry."""
     if ':' not in path:

--- a/tests/func/Makefile
+++ b/tests/func/Makefile
@@ -1,9 +1,13 @@
 default:
 
+rpm:
+	make -C ../../packaging rpm
+
 tests:
 	docker-compose up --abort-on-container-exit runner
 
 clean:
+	make -C ../../packaging clean
 	docker-compose down -v
 
 debug:

--- a/tests/func/README.md
+++ b/tests/func/README.md
@@ -3,8 +3,8 @@
 Functionnal tests tends to integrate ldap2pg in real world: execution in target
 system, installation from rpm package, no mocks.
 
-1. Create RPM package with `make -C ../../packaging/ distclean rpm trash`.
-2. Run tests with `make tests`.
+Run `make clean rpm tests` to recreate rpm and test env.
 
 On error, the container wait forever. Either enter the container with `make
-debug` or kill it with ^C.
+debug` or kill it with ^C. To reduce dev loop, just `pip install -e .` to use
+wip code rather than rpm version.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -57,6 +57,15 @@ def test_mapping():
         )
 
 
+def test_processor():
+    from ldap2pg.config import Mapping
+
+    m = Mapping('dry', processor=bool)
+    v = m.process(default=True, file_config=dict(dry=0), environ=dict())
+
+    assert v is False
+
+
 def test_find_filename(mocker):
     stat = mocker.patch('ldap2pg.config.stat')
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,6 +6,10 @@ import pytest
 def test_mapping():
     from ldap2pg.config import Mapping
 
+    m = Mapping('sync_map', env=None)
+    v = m.process(default='defval', file_config=dict(), environ=dict())
+    assert 'defval' == v
+
     m = Mapping('ldap:password', secret=True)
     assert 'LDAP_PASSWORD' == m.env
 

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -41,11 +41,26 @@ def test_fetch_wanted_roles(mocker):
         mocker.Mock(cn=mocker.Mock(value='alice')),
         mocker.Mock(cn=mocker.Mock(value='bob')),
     ]
-    wanted_roles = manager.fetch_ldap_roles(
-        base='ou=people,dc=global', query='(objectClass=*)',
+    entries = manager.query_ldap(
+        base='ou=people,dc=global', filter='(objectClass=*)',
+        attributes=['cn'],
     )
 
-    assert {'alice', 'bob'} == wanted_roles
+    assert 2 == len(entries)
+
+
+def test_process_entry(mocker):
+    from ldap2pg.manager import RoleManager
+
+    manager = RoleManager(pgconn=mocker.Mock(), ldapconn=mocker.Mock())
+
+    entry = mocker.Mock(entry_attributes_as_dict=dict(cn=['alice', 'bob']))
+
+    roles = manager.process_ldap_entry(entry, name_attribute='cn')
+
+    assert 2 == len(roles)
+    assert 'alice' in roles
+    assert 'bob' in roles
 
 
 def test_create(mocker):
@@ -88,12 +103,23 @@ def test_drop(mocker):
 
 def test_sync(mocker):
     p = mocker.patch('ldap2pg.manager.RoleManager.fetch_pg_roles')
-    l = mocker.patch('ldap2pg.manager.RoleManager.fetch_ldap_roles')
+    l = mocker.patch('ldap2pg.manager.RoleManager.query_ldap')
+    r = mocker.patch('ldap2pg.manager.RoleManager.process_ldap_entry')
 
     p.return_value = set('spurious')
-    l.return_value = {'alice', 'bob'}
+    l.return_value = [mocker.Mock(name='entry')]
+    r.return_value = {'alice', 'bob'}
 
     from ldap2pg.manager import RoleManager
 
     manager = RoleManager(pgconn=mocker.Mock(), ldapconn=mocker.Mock())
-    manager.sync(base='ou=people,dc=global', query='(objectClass=*)')
+    map_ = [
+        dict(
+            ldap=dict(
+                base='ou=people,dc=global', filter='(objectClass=*)',
+                attributes=['cn'],
+            ),
+            role=dict(name_attribute='cn')
+        ),
+    ]
+    manager.sync(map_=map_)

--- a/tests/unit/test_script.py
+++ b/tests/unit/test_script.py
@@ -58,6 +58,7 @@ def test_pdb(mocker):
 
 
 def test_wrapped_main(mocker):
+    c = mocker.patch('ldap2pg.script.Configuration', autospec=True)
     clc = mocker.patch('ldap2pg.script.create_ldap_connection')
     cpc = mocker.patch('ldap2pg.script.create_pg_connection')
     rm = mocker.patch('ldap2pg.script.RoleManager', autospec=True)
@@ -66,6 +67,7 @@ def test_wrapped_main(mocker):
 
     wrapped_main()
 
+    assert c.called is True
     assert clc.called is True
     assert cpc.called is True
     assert rm.called is True

--- a/tests/unit/test_script.py
+++ b/tests/unit/test_script.py
@@ -2,11 +2,8 @@ import pytest
 
 
 def test_main(mocker):
-    mocker.patch('ldap2pg.script.logging.basicConfig')
-    mocker.patch('ldap2pg.script.Configuration')
-    mocker.patch('ldap2pg.script.create_ldap_connection')
-    mocker.patch('ldap2pg.script.create_pg_connection')
-    mocker.patch('ldap2pg.script.RoleManager')
+    mocker.patch('ldap2pg.script.logging.basicConfig', autospec=True)
+    mocker.patch('ldap2pg.script.wrapped_main', autospec=True)
 
     from ldap2pg.script import main
 
@@ -58,6 +55,20 @@ def test_pdb(mocker):
 
     assert pm.called is True
     assert 1 == ei.value.code
+
+
+def test_wrapped_main(mocker):
+    clc = mocker.patch('ldap2pg.script.create_ldap_connection')
+    cpc = mocker.patch('ldap2pg.script.create_pg_connection')
+    rm = mocker.patch('ldap2pg.script.RoleManager', autospec=True)
+
+    from ldap2pg.script import wrapped_main
+
+    wrapped_main()
+
+    assert clc.called is True
+    assert cpc.called is True
+    assert rm.called is True
 
 
 def test_create_ldap(mocker):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,17 +1,6 @@
 import pytest
 
 
-def test_deep_update():
-    from ldap2pg.utils import deepupdate
-
-    a = dict(toto=dict(tata=1))
-    b = dict(toto=dict(titi=2))
-
-    deepupdate(a, b)
-
-    assert dict(tata=1, titi=2) == a['toto']
-
-
 def test_deep_getset():
     from ldap2pg.utils import deepget, deepset
 


### PR DESCRIPTION
Implement new file format:

``` yaml
sync_map:
- ldap:
    base: ...
    filter: ...
    attributes: [cn]
  role:
    name_attribute: cn
```

This new format allow multiple LDAP queries and custom entry/role mapping.