### PR TITLE
Manage role options

### DIFF
--- a/dev-fixture.sql
+++ b/dev-fixture.sql
@@ -1,0 +1,9 @@
+DROP ROLE IF EXISTS spurious;
+DROP ROLE IF EXISTS alice;
+DROP ROLE IF EXISTS bob;
+DROP ROLE IF EXISTS foo;
+DROP ROLE IF EXISTS bar;
+-- Create a spurious user, for DROP.
+CREATE ROLE spurious WITH LOGIN;
+-- Create alice superuser without login, for ALTER.
+CREATE ROLE alice WITH SUPERUSER NOLOGIN;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,5 @@ services:
 
   postgres:
     image: postgres:9.6
+    volumes:
+    - ./dev-fixture.sql:/docker-entrypoint-initdb.d/dev-fixture.sql

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -1,10 +1,77 @@
-ldap:
-  bind: cn=admin,dc=ldap2pg,dc=local
+#
+# **LDAP2PG CONFIGURATION**
+#
+# ldap2pg file is a regular YAML file. File mode must be 0600 if you store a
+# password in it.
+#
+# This file is tested under CI with real OpenLDAP and Postgres services. To test
+# it: clone the repository, run pip install -e ., run docker-compose -d then
+# just run ldap2pg. See dev-fixture.ldif and dev-fixture.sql for details on data
+# migrated.
+#
+# ldap2pg accepts a special env vars: DEBUG with values 1, y or Y. This enable
+# verbose logging. If ldap2pg is executed from a terminal, a debugger is
+# triggered on unhandled error.
 
+# Dry mode. env var: DRY=[1yY]
+dry: no
+
+#
+# **LDAP connection**
+#
+ldap:
+  # env vars: LDAP_HOST
+  host: ldap2pg.local
+  # env vars: LDAP_PORT
+  port: 389
+  # env vars: LDAP_BIND
+  bind: cn=admin,dc=ldap2pg,dc=local
+  # env vars: LDAP_PASSWORD
+  password: SECRET
+
+#
+# **Postgres connection**
+#
+# Standard libpq env vars are supported: PGHOST, PGPORT, PGUSER, PGPASSWORD,
+# .pgpass, etc.
+#
+# PGDSN env var is supported as well.
+#
+# postgres:
+#   dsn: postgres://user:SECRET@host:port/dbname
+#   dsn: postgres://user@%2Fvar%2Frun%2Fpostgresql:port/dbname
+#   dsn: host=host port=port user=postgres password=secret dbname=postgres
+
+#
+# **Synchronization map**
+#
+# SyncMap is an ordered list of mapping. Each mapping describes an LDAP query
+# and a set of rules to generate roles from entries returned by LDAP.
 sync_map:
 - ldap:
-    base: ou=groups,dc=ldap2pg,dc=local
+    base: cn=dba,ou=groups,dc=ldap2pg,dc=local
     filter: "(objectClass=groupOfNames)"
-    attributes: [cn, member]
+    attribute: member
+  # A signe rule to generate roles for each entries.
   role:
+    # *_attribute means the value is the name of an attribute in the entry. A
+    # role is generated for each value of the attribute. If the attribute is a
+    # distinguishedName, you can specify which part of the DN to read instead of
+    # all the attribute value.
+    #
+    #
+    # e.g. `member: cn=alice,dc=company,dc=com` generates `CREATE ROLE alice;`
+    #
     name_attribute: member.cn
+    # Postgres role options: Can be a regular SQL snippet, a list or a dict.
+    options: LOGIN SUPERUSER NOBYPASSRLS
+- ldap:
+    base: ou=groups,dc=ldap2pg,dc=local
+    filter: "(&(objectClass=groupOfNames)(cn=app*))"
+    attributes: [member]
+  # A list of rules to generate roles. Each rules is applied on each LDAP
+  # entries.
+  roles:
+  - name_attribute: member.cn
+    options:
+      LOGIN: yes

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -39,8 +39,6 @@ def syncmap(value):
         if 'attribute' in ldap:
             ldap['attributes'] = ldap['attribute']
             del ldap['attribute']
-        if isinstance(ldap['attributes'], str):
-            ldap['attributes'] = [ldap['attributes']]
 
         if 'role' in item:
             item['roles'] = [item['role']]

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -14,6 +14,7 @@ from .utils import (
     deepset,
     UserError,
 )
+from .role import RoleOptions
 
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,23 @@ logger = logging.getLogger(__name__)
 
 def raw(v):
     return v
+
+
+def rolerule(value):
+    rule = value
+    options = rule.setdefault('options', {})
+
+    if isinstance(options, string_types):
+        options = options.split()
+
+    if isinstance(options, list):
+        options = {
+            o.lstrip('NO'): not o.startswith('NO')
+            for o in options
+        }
+
+    rule['options'] = RoleOptions(**options)
+    return rule
 
 
 def syncmap(value):
@@ -45,6 +63,9 @@ def syncmap(value):
 
         if 'roles' not in item:
             raise ValueError("Missing roles entry.")
+
+        for i, rule in enumerate(item['roles']):
+            item['roles'][i] = rolerule(rule)
 
     return value
 

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -128,6 +128,8 @@ class RoleManager(object):
                     continue
 
                 self.psql(query)
+            else:
+                logger.info("Nothing to do.")
 
         logger.info("Synchronization complete.")
         return ldaproles

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -44,10 +44,13 @@ class RoleManager(object):
         return {r[0] for r in payload}
 
     def query_ldap(self, base, filter, attributes):
-        logger.debug("Querying LDAP...")
-        self.ldapconn.search(
-            base, filter, attributes=attributes,
+        logger.debug(
+            "ldapsearch -h %s -p %s -D %s -W -b %s '%s' %s",
+            self.ldapconn.server.host, self.ldapconn.server.port,
+            self.ldapconn.user,
+            base, filter, ' '.join(attributes or []),
         )
+        self.ldapconn.search(base, filter, attributes=attributes)
         return self.ldapconn.entries[:]
 
     def process_ldap_entry(self, entry, name_attribute):

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -31,6 +31,7 @@ class RoleManager(object):
         for i in items:
             for pattern in self._blacklist:
                 if fnmatch(i, pattern):
+                    logger.debug("Ignoring role %s. Matches %r.", i, pattern)
                     break
             else:
                 yield i

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -53,7 +53,7 @@ class RoleManager(object):
         self.ldapconn.search(base, filter, attributes=attributes)
         return self.ldapconn.entries[:]
 
-    def process_ldap_entry(self, entry, name_attribute):
+    def process_ldap_entry(self, entry, name_attribute, **kw):
         path = name_attribute.split('.')
         values = entry.entry_attributes_as_dict[path[0]]
         path = path[1:]

--- a/ldap2pg/role.py
+++ b/ldap2pg/role.py
@@ -1,0 +1,100 @@
+from __future__ import unicode_literals
+
+from collections import OrderedDict
+
+
+class Role(object):
+    def __init__(self, name, options=None):
+        self.name = name
+        self.options = RoleOptions(options or {})
+
+    def __eq__(self, other):
+        return self.name == str(other)
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __repr__(self):
+        return '<%s %s>' % (self.__class__.__name__, self.name)
+
+    def __str__(self):
+        return self.name
+
+    @classmethod
+    def from_row(cls, name, *row):
+        self = Role(name=name)
+        self.options.update_from_row(row)
+        return self
+
+
+class RoleOptions(dict):
+    COLUMNS_MAP = OrderedDict([
+        ('BYPASSRLS', 'rolbypassrls'),
+        ('LOGIN', 'rolcanlogin'),
+        ('CREATEDB', 'rolcreatedb'),
+        ('CREATEROLE', 'rolcreaterole'),
+        ('REPLICATION', 'rolreplication'),
+        ('SUPERUSER', 'rolsuper'),
+    ])
+
+    def __init__(self, *a, **kw):
+        super(RoleOptions, self).__init__(
+            BYPASSRLS=False,
+            LOGIN=False,
+            CREATEDB=False,
+            CREATEROLE=False,
+            REPLICATION=False,
+            SUPERUSER=False,
+        )
+        init = dict(*a, **kw)
+        self.update(init)
+
+    def __repr__(self):
+        return '<%s %s>' % (self.__class__.__name__, self)
+
+    def __str__(self):
+        return ' '.join((
+            ('NO' if value is False else '') + name
+            for name, value in self.items()
+        ))
+
+    def update_from_row(self, row):
+        self.update(dict(zip(self.COLUMNS_MAP.keys(), row)))
+
+    def update(self, other):
+        spurious_options = set(other.keys()) - set(self.keys())
+        if spurious_options:
+            message = "Unknown options %s" % (', '.join(spurious_options),)
+            raise ValueError(message)
+        return super(RoleOptions, self).update(other)
+
+
+class RoleSet(set):
+    def __init__(self, *a, **kw):
+        super(RoleSet, self).__init__(*a, **kw)
+
+    def reindex(self):
+        return {
+            role.name: role
+            for role in self
+        }
+
+    def diff(self, other):
+        # Yields SQL queries to synchronize self with other.
+        spurious = self - other
+        for role in spurious:
+            yield 'DROP ROLE %s;' % (role.name)
+
+        existing = self & other
+        myindex = self.reindex()
+        itsindex = other.reindex()
+        for role in existing:
+            my = myindex[role.name]
+            its = itsindex[role.name]
+            if my.options == its.options:
+                continue
+            yield 'ALTER ROLE %s WITH %s;' % (role.name, its.options)
+
+        missing = other - self
+        for role in missing:
+            yield 'CREATE ROLE %s WITH %s;' % (role.name, role.options)

--- a/tests/func/test_000-run.sh
+++ b/tests/func/test_000-run.sh
@@ -1,9 +1,7 @@
 #!/bin/bash -eux
 
-# fixture
-createuser spurious
-
-# Check OpenLDAP access and load fixtures
+# Fixtures
+psql < dev-fixture.sql
 ldapadd -v -h $LDAP_HOST -D $LDAP_BIND -w $LDAP_PASSWORD -f dev-fixture.ldif
 
 # Case dry run
@@ -18,5 +16,5 @@ DEBUG=1 ldap2pg
 ! psql -c 'SELECT rolname FROM pg_roles;' | grep -q spurious
 test ${PIPESTATUS[0]} -eq 0
 
-psql -c 'SELECT rolname FROM pg_roles;' | grep -q alice
+psql -c 'SELECT rolname FROM pg_roles WHERE rolsuper IS TRUE AND rolcanlogin IS TRUE;' | grep -q alice
 psql -c 'SELECT rolname FROM pg_roles;' | grep -q bob

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -93,6 +93,22 @@ def test_process_syncmap():
         syncmap(raw)
 
 
+def test_process_rolerule():
+    from ldap2pg.config import rolerule
+
+    rule = rolerule(dict(options='LOGIN SUPERUSER'))
+    assert rule['options']['LOGIN'] is True
+    assert rule['options']['SUPERUSER'] is True
+
+    rule = rolerule(dict(options=['LOGIN', 'SUPERUSER']))
+    assert rule['options']['LOGIN'] is True
+    assert rule['options']['SUPERUSER'] is True
+
+    rule = rolerule(dict(options=['NOLOGIN', 'SUPERUSER']))
+    assert rule['options']['LOGIN'] is False
+    assert rule['options']['SUPERUSER'] is True
+
+
 def test_find_filename(mocker):
     stat = mocker.patch('ldap2pg.config.stat')
 

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1,4 +1,16 @@
+from __future__ import unicode_literals
+
 import pytest
+
+
+def test_role():
+    from ldap2pg.manager import Role
+
+    role = Role(name='toto')
+
+    assert 'toto' == role.name
+    assert 'toto' == str(role)
+    assert 'toto' in repr(role)
 
 
 def test_context_manager(mocker):
@@ -32,7 +44,7 @@ def test_fetch_existing_roles(mocker):
     ]
     existing_roles = manager.fetch_pg_roles()
 
-    assert {'alice', 'bob'} == existing_roles
+    assert {'alice', 'bob'} == {r.name for r in existing_roles}
 
 
 def test_fetch_wanted_roles(mocker):
@@ -73,10 +85,11 @@ def test_process_entry(mocker):
 
     roles = manager.process_ldap_entry(entry, name_attribute='member.cn')
     roles = list(roles)
+    names = {r.name for r in roles}
 
     assert 2 == len(roles)
-    assert 'alice' in roles
-    assert 'bob' in roles
+    assert 'alice' in names
+    assert 'bob' in names
 
 
 def test_create(mocker):

--- a/tests/unit/test_role.py
+++ b/tests/unit/test_role.py
@@ -1,0 +1,50 @@
+from __future__ import unicode_literals
+
+from fnmatch import filter as fnfilter
+
+import pytest
+
+
+def test_role():
+    from ldap2pg.manager import Role
+
+    role = Role(name='toto')
+
+    assert 'toto' == role.name
+    assert 'toto' == str(role)
+    assert 'toto' in repr(role)
+
+
+def test_options():
+    from ldap2pg.manager import RoleOptions
+
+    options = RoleOptions()
+
+    assert 'NOSUPERUSER' in repr(options)
+
+    with pytest.raises(ValueError):
+        options.update(dict(POUET=True))
+
+    with pytest.raises(ValueError):
+        RoleOptions(POUET=True)
+
+
+def test_roles_diff_queries():
+    from ldap2pg.manager import Role, RoleSet
+
+    a = RoleSet([
+        Role('drop-me'),
+        Role('alter-me'),
+        Role('nothing'),
+    ])
+    b = RoleSet([
+        Role('alter-me', options=dict(LOGIN=True)),
+        Role('nothing'),
+        Role('create-me')
+    ])
+    queries = list(a.diff(b))
+
+    assert fnfilter(queries, "ALTER ROLE alter-me WITH* LOGIN*;")
+    assert fnfilter(queries, "CREATE ROLE create-me *;")
+    assert 'DROP ROLE drop-me;' in queries
+    assert not fnfilter(queries, '*nothing*')


### PR DESCRIPTION
This PR allows to manage boolean options of roles.

- Add options on creation
- Add or remove options with `ALTER ROLE`.
- Reads options from config file:
  - as `dict`, `list` or `str` see example below.
- As a side contribution of working on this, log messages has been reviewed.
  - **every** SQL queries are logged
  - LDAP searches are logged as `ldapsearch` CLI commands

### Sample configuration

``` yaml
sync_map:
- ldap: {}
  roles:
  - name_attribute: cn
    options:
        LOGIN: yes
  - name_attribute: cn
    options: [LOGIN]
  - name_attribute: cn
    options: LOGIN
```
