### PR TITLE
Complete CLI args

### DIFF
--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -19,10 +19,6 @@ verbose: yes
 # Dry mode. env var: DRY=[1yY]
 dry: no
 
-# Increase messages verbosity. Logs every SQL queries. logs each LDAP searches
-# as ldapsearch commands. env var: VERBOSE=[1yY]
-verbose: no
-
 #
 # **LDAP connection**
 #

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -13,8 +13,15 @@
 # verbose logging. If ldap2pg is executed from a terminal, a debugger is
 # triggered on unhandled error.
 
+# Verbose messages. Includes SQL and LDAP queries. env var: VERBOSE
+verbose: yes
+
 # Dry mode. env var: DRY=[1yY]
 dry: no
+
+# Increase messages verbosity. Logs every SQL queries. logs each LDAP searches
+# as ldapsearch commands. env var: VERBOSE=[1yY]
+verbose: no
 
 #
 # **LDAP connection**

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -13,6 +13,9 @@
 # verbose logging. If ldap2pg is executed from a terminal, a debugger is
 # triggered on unhandled error.
 
+# Colorization. env var: COLOR=<anything>
+color: yes
+
 # Verbose messages. Includes SQL and LDAP queries. env var: VERBOSE
 verbose: yes
 

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -170,7 +170,7 @@ class Mapping(object):
         for env in self.env:
             try:
                 value = environ[env]
-                logger.debug("Loaded %s from %s.", self.path, env)
+                logger.debug("Read %s from %s.", self.path, env)
                 break
             except KeyError:
                 continue
@@ -194,11 +194,14 @@ class Mapping(object):
         if secret and unsecured_file:
             raise ValueError("Refuse to load secret from world readable file.")
 
+        logger.debug("Read %s from YAML.", self.path)
         return value
 
     def process_arg(self, args):
         # Get value from argparse result.
-        return getattr(args, self.arg)
+        value = getattr(args, self.arg)
+        logger.debug("Read %s from argv.", self.path)
+        return value
 
     def process(self, default, file_config={}, environ={}, args=object()):
         # This is the sources of configuration, ordered by priority desc. If a

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -112,10 +112,6 @@ def syncmap(value):
 
 def define_arguments(parser):
     parser.add_argument(
-        '-?', '--help',
-        action='help',
-        help='show this help message and exit')
-    parser.add_argument(
         '-c', '--config',
         action='store', dest='config',
         help='path to YAML configuration file'
@@ -130,6 +126,10 @@ def define_arguments(parser):
         action='store_true', dest='verbose',
         help="add debug messages including SQL and LDAP queries"
     )
+    parser.add_argument(
+        '-?', '--help',
+        action='help',
+        help='show this help message and exit')
 
 
 class Mapping(object):

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -115,22 +115,22 @@ def define_arguments(parser):
     parser.add_argument(
         '-c', '--config',
         action='store', dest='config',
-        help='path to YAML configuration file'
+        help='path to YAML configuration file (env: LDAP2PG_CONFIG)'
     )
     parser.add_argument(
         '-n', '--dry',
         action='store_true', dest='dry',
-        help="don't touch Postgres, just print what to do"
+        help="don't touch Postgres, just print what to do (env: DRY)"
     )
     parser.add_argument(
         '-N', '--real',
         action='store_false', dest='dry',
-        help="real mode, apply changes to Postgres"
+        help="real mode, apply changes to Postgres (env: DRY)"
     )
     parser.add_argument(
         '-v', '--verbose',
         action='store_true', dest='verbose',
-        help="add debug messages including SQL and LDAP queries"
+        help="add debug messages including SQL and LDAP queries (env: VERBOSE)"
     )
     parser.add_argument(
         '-?', '--help',

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -282,7 +282,7 @@ class Configuration(dict):
                 return candidate, stat_.st_mode
             except OSError as e:
                 if e.errno == errno.EACCES:
-                    logger.warn("Can't try %s: permission denied.", candidate)
+                    logger.warn("Can't read %s: permission denied.", candidate)
 
         if custom:
             message = "Can't access configuration file %s." % (custom,)
@@ -322,8 +322,12 @@ class Configuration(dict):
             file_config = {}
         else:
             logger.debug("Opening configuration file %s.", filename)
-            with open(filename) as fo:
-                file_config = self.read(fo, mode)
+            try:
+                with open(filename) as fo:
+                    file_config = self.read(fo, mode)
+            except OSError as e:
+                msg = "Failed to read configuration: %s" % (e,)
+                raise UserError(msg)
 
         # Now merge all config sources.
         try:

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -235,7 +235,7 @@ class NoConfigurationError(Exception):
 
 class Configuration(dict):
     DEFAULTS = {
-        'dry': False,
+        'dry': True,
         'verbose': False,
         'ldap': {
             'host': '',
@@ -306,6 +306,8 @@ class Configuration(dict):
 
     ldap2pg requires a configuration file to describe LDAP queries and
     role mappings. See project home for further details.
+
+    By default, ldap2pg runs in dry mode.
     """.replace(4 * ' ', '')
 
     def load(self, argv=None):

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -123,6 +123,11 @@ def define_arguments(parser):
         help="don't touch Postgres, just print what to do"
     )
     parser.add_argument(
+        '-N', '--real',
+        action='store_false', dest='dry',
+        help="real mode, apply changes to Postgres"
+    )
+    parser.add_argument(
         '-v', '--verbose',
         action='store_true', dest='verbose',
         help="add debug messages including SQL and LDAP queries"

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -116,6 +116,11 @@ def define_arguments(parser):
         action='help',
         help='show this help message and exit')
     parser.add_argument(
+        '-c', '--config',
+        action='store', dest='config',
+        help='path to YAML configuration file'
+    )
+    parser.add_argument(
         '-n', '--dry',
         action='store_true', dest='dry',
         help="don't touch Postgres, just print what to do"
@@ -262,10 +267,10 @@ class Configuration(dict):
         '/etc/ldap2pg.yml',
     ]
 
-    def find_filename(self, environ=os.environ):
-        envval = environ.get('LDAP2PG_CONFIG')
-        if envval:
-            candidates = [envval]
+    def find_filename(self, environ=os.environ, args=None):
+        custom = getattr(args, 'config', environ.get('LDAP2PG_CONFIG'))
+        if custom:
+            candidates = [custom]
         else:
             candidates = self._file_candidates
 
@@ -306,7 +311,7 @@ class Configuration(dict):
 
         # File loading.
         try:
-            filename, mode = self.find_filename(environ=os.environ)
+            filename, mode = self.find_filename(environ=os.environ, args=args)
         except NoConfigurationError:
             logger.debug("No configuration file found.")
             file_config = {}

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -283,7 +283,12 @@ class Configuration(dict):
             except OSError as e:
                 if e.errno == errno.EACCES:
                     logger.warn("Can't try %s: permission denied.", candidate)
-        raise NoConfigurationError("No configuration file found")
+
+        if custom:
+            message = "Can't access configuration file %s." % (custom,)
+            raise UserError(message, exit_code=os.EX_NOINPUT)
+        else:
+            raise NoConfigurationError("No configuration file found")
 
     EPILOG = """\
 

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -288,6 +288,7 @@ class Configuration(dict):
 
     def load(self, argv=None):
         # argv processing.
+        logger.debug("Processing CLI arguments.")
         parser = ArgumentParser(
             add_help=False,
             # Only store value from argv. Defaults are managed by
@@ -298,6 +299,10 @@ class Configuration(dict):
         )
         define_arguments(parser)
         args = parser.parse_args(sys.argv if argv is None else argv)
+
+        if hasattr(args, 'verbose'):
+            self['verbose'] = args.verbose
+            logging.config.dictConfig(self.logging_dict())
 
         # File loading.
         try:

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -11,6 +11,7 @@ import sys
 from six import string_types
 import yaml
 
+from . import __version__
 from .utils import (
     deepget,
     deepset,
@@ -130,6 +131,12 @@ def define_arguments(parser):
         '-?', '--help',
         action='help',
         help='show this help message and exit')
+    parser.add_argument(
+        '-V', '--version',
+        action='version',
+        help='show version and exit',
+        version=__package__ + ' ' + __version__,
+    )
 
 
 class Mapping(object):

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -33,7 +33,7 @@ def wrapped_main(config=None):
     config = config or Configuration()
     config.load()
 
-    logging_config = config.logging_dict(tty=sys.stderr.isatty())
+    logging_config = config.logging_dict()
     logging.config.dictConfig(logging_config)
 
     logger.info("Starting ldap2pg %s.", __version__)
@@ -63,6 +63,7 @@ def main():
 
     config = Configuration()
     config['verbose'] = debug or verbose
+    config['color'] = sys.stderr.isatty()
     logging.config.dictConfig(config.logging_dict())
 
     try:

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -9,6 +9,7 @@ import sys
 import ldap3
 import psycopg2
 
+from . import __version__
 from .config import Configuration, ConfigurationError
 from .manager import RoleManager
 from .utils import UserError
@@ -28,9 +29,15 @@ def create_pg_connection(dsn):
     return psycopg2.connect(dsn)
 
 
-def wrapped_main(debug=False):
+def wrapped_main():
     config = Configuration()
-    config.load(debug=debug)
+    config.load()
+
+    logging_config = config.logging_dict(tty=sys.stderr.isatty())
+    logging.config.dictConfig(logging_config)
+
+    logger.info("Starting ldap2pg %s.", __version__)
+    logger.debug("Debug mode enabled.")
 
     try:
         ldapconn = create_ldap_connection(**config['ldap'])
@@ -54,7 +61,7 @@ def main():
     debug = os.environ.get('DEBUG', '').lower() in {'1', 'y'}
 
     try:
-        wrapped_main(debug=debug)
+        wrapped_main()
         exit(0)
     except pdb.bdb.BdbQuit:
         logger.info("Graceful exit from debugger.")

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import logging
+import logging.config
 import os
 import pdb
 import sys
@@ -29,8 +29,8 @@ def create_pg_connection(dsn):
     return psycopg2.connect(dsn)
 
 
-def wrapped_main():
-    config = Configuration()
+def wrapped_main(config=None):
+    config = config or Configuration()
     config.load()
 
     logging_config = config.logging_dict(tty=sys.stderr.isatty())
@@ -59,9 +59,14 @@ def wrapped_main():
 
 def main():
     debug = os.environ.get('DEBUG', '').lower() in {'1', 'y'}
+    verbose = os.environ.get('VERBOSE', '').lower() in {'1', 'y'}
+
+    config = Configuration()
+    config['verbose'] = debug or verbose
+    logging.config.dictConfig(config.logging_dict())
 
     try:
-        wrapped_main()
+        wrapped_main(config)
         exit(0)
     except pdb.bdb.BdbQuit:
         logger.info("Graceful exit from debugger.")

--- a/tests/func/test_config.sh
+++ b/tests/func/test_config.sh
@@ -34,4 +34,4 @@ sandbox="env ${var_bl[@]/#/--unset }"
 chmod 0600 ${LDAP2PG_CONFIG}
 
 # Now it's ok :)
-$sandbox ldap2pg
+$sandbox ldap2pg -N

--- a/tests/func/test_config.sh
+++ b/tests/func/test_config.sh
@@ -2,7 +2,7 @@
 
 ldap2pg --help
 ldap2pg -?
-ldap2pg -vn
+ldap2pg -vn --color
 
 export LDAP2PG_CONFIG=my-test-ldap2pg.yml
 rm -f $LDAP2PG_CONFIG

--- a/tests/func/test_config.sh
+++ b/tests/func/test_config.sh
@@ -2,7 +2,7 @@
 
 ldap2pg --help
 ldap2pg -?
-ldap2pg -dn
+ldap2pg -vn
 
 export LDAP2PG_CONFIG=my-test-ldap2pg.yml
 rm -f $LDAP2PG_CONFIG

--- a/tests/func/test_sync.sh
+++ b/tests/func/test_sync.sh
@@ -13,6 +13,7 @@ list_members() {
 SELECT m.rolname FROM pg_roles AS m
 JOIN pg_auth_members a ON a.member = m.oid
 JOIN pg_roles AS r ON r.oid = a.roleid
+WHERE r.rolname = '$1'
 ORDER BY 1;
 EOSQL
 }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -37,16 +37,16 @@ def test_multiline_formatter():
     assert wanted == payload
 
 
-def test_color_formatter():
+def test_color_handler():
     import logging
-    from ldap2pg.config import ColorFormatter
+    from ldap2pg.config import ColoredStreamHandler
 
-    formatter = ColorFormatter("%(message)s")
+    handler = ColoredStreamHandler()
     record = logging.makeLogRecord(dict(
         name='pouet', level=logging.DEBUG, fn="(unknown file)", msg="Message",
         lno=0, args=(), exc_info=None,
     ))
-    payload = formatter.format(record)
+    payload = handler.format(record)
     assert "\033[0" in payload
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -355,12 +355,13 @@ def test_load(mocker):
     mocker.patch('ldap2pg.config.os.environ', environ)
     ff = mocker.patch('ldap2pg.config.Configuration.find_filename')
     read = mocker.patch('ldap2pg.config.Configuration.read')
-    mocker.patch('ldap2pg.config.open', create=True)
+    o = mocker.patch('ldap2pg.config.open', create=True)
 
     from ldap2pg.config import (
         Configuration,
         ConfigurationError,
         NoConfigurationError,
+        UserError,
     )
 
     config = Configuration()
@@ -373,6 +374,14 @@ def test_load(mocker):
     ff.side_effect = None
     # Find `filename.yml`
     ff.return_value = ['filename.yml', 0o0]
+
+    # Not readable.
+    o.side_effect = OSError("failed to open")
+    with pytest.raises(UserError):
+        config.load(argv=[])
+
+    # Readable..
+    o.side_effect = None
     # ...containing mapping
     read.return_value = dict(sync_map=dict(ldap=dict(), role=dict()))
     # send one env var for LDAP bind

--- a/tests/unit/test_script.py
+++ b/tests/unit/test_script.py
@@ -4,6 +4,7 @@ import pytest
 
 
 def test_main(mocker):
+    mocker.patch('ldap2pg.script.logging.config.dictConfig', autospec=True)
     mocker.patch('ldap2pg.script.wrapped_main', autospec=True)
 
     from ldap2pg.script import main
@@ -15,6 +16,7 @@ def test_main(mocker):
 
 
 def test_bdb_quit(mocker):
+    mocker.patch('ldap2pg.script.logging.config.dictConfig', autospec=True)
     w = mocker.patch('ldap2pg.script.wrapped_main')
 
     from ldap2pg.script import main, pdb
@@ -28,6 +30,7 @@ def test_bdb_quit(mocker):
 
 
 def test_unhandled_error(mocker):
+    mocker.patch('ldap2pg.script.logging.config.dictConfig', autospec=True)
     w = mocker.patch('ldap2pg.script.wrapped_main')
 
     from ldap2pg.script import main
@@ -41,6 +44,7 @@ def test_unhandled_error(mocker):
 
 
 def test_user_error(mocker):
+    mocker.patch('ldap2pg.script.logging.config.dictConfig', autospec=True)
     w = mocker.patch('ldap2pg.script.wrapped_main')
 
     from ldap2pg.script import main, UserError
@@ -54,6 +58,7 @@ def test_user_error(mocker):
 
 
 def test_pdb(mocker):
+    mocker.patch('ldap2pg.script.logging.config.dictConfig', autospec=True)
     mocker.patch('ldap2pg.script.os.environ', {'DEBUG': '1'})
     isatty = mocker.patch('ldap2pg.script.sys.stdout.isatty')
     isatty.return_value = True
@@ -71,6 +76,7 @@ def test_pdb(mocker):
 
 
 def test_wrapped_main(mocker):
+    mocker.patch('ldap2pg.script.logging.config.dictConfig', autospec=True)
     c = mocker.patch('ldap2pg.script.Configuration', autospec=True)
     clc = mocker.patch('ldap2pg.script.create_ldap_connection')
     cpc = mocker.patch('ldap2pg.script.create_pg_connection')
@@ -87,6 +93,7 @@ def test_wrapped_main(mocker):
 
 
 def test_conn_errors(mocker):
+    mocker.patch('ldap2pg.script.logging.config.dictConfig', autospec=True)
     mocker.patch('ldap2pg.script.Configuration', autospec=True)
     clc = mocker.patch('ldap2pg.script.create_ldap_connection')
     cpc = mocker.patch('ldap2pg.script.create_pg_connection')
@@ -107,6 +114,7 @@ def test_conn_errors(mocker):
 
 
 def test_create_ldap(mocker):
+    mocker.patch('ldap2pg.script.logging.config.dictConfig', autospec=True)
     mocker.patch('ldap2pg.script.ldap3.Connection', autospec=True)
     from ldap2pg.script import create_ldap_connection
 


### PR DESCRIPTION
``` console
$ ldap2pg --help
usage: ldap2pg [-c CONFIG] [-n] [-N] [-v] [--color] [--no-color] [-?] [-V]

Swiss-army knife to sync Postgres ACL from LDAP.

optional arguments:
  -c CONFIG, --config CONFIG
                        path to YAML configuration file (env: LDAP2PG_CONFIG)
  -n, --dry             don't touch Postgres, just print what to do (env: DRY)
  -N, --real            real mode, apply changes to Postgres (env: DRY)
  -v, --verbose         add debug messages including SQL and LDAP queries
                        (env: VERBOSE)
  --color               force color output (env: COLOR)
  --no-color            force plain text output (env: COLOR)
  -?, --help            show this help message and exit
  -V, --version         show version and exit

ldap2pg requires a configuration file to describe LDAP queries and role
mappings. See project home for further details. By default, ldap2pg runs in
dry mode.
```