### PR TITLE
Drop rowcount integrity check

### DIFF
--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -92,7 +92,6 @@ class RoleManager(object):
         logger.debug("Doing: %s", sql.decode('utf-8'))
         self.pgcursor.execute(sql)
         self.pgconn.commit()
-        logger.debug("rowcount: %s", self.pgcursor.rowcount)
 
     def query_ldap(self, base, filter, attributes):
         logger.debug(
@@ -155,13 +154,6 @@ class RoleManager(object):
                 for role in self.process_ldap_entry(entry=entry, **rule):
                     yield role
 
-    def check_last_rowcount(self, rowcount):
-        if rowcount != self.pgcursor.rowcount:
-            msg = "rowcount is not as expected: expects %s, got %s." % (
-                rowcount, self.pgcursor.rowcount,
-            )
-            raise Exception(msg)
-
     def sync(self, map_):
         logger.info("Inspecting Postgres...")
         rows = self.fetch_pg_roles()
@@ -192,7 +184,6 @@ class RoleManager(object):
                 logger.debug("Would execute: %s", sql)
             else:
                 self.psql(sql)
-                self.check_last_rowcount(query.rowcount)
         count = count + 1
         logger.debug("Executed %d querie(s).", count)
 

--- a/ldap2pg/role.py
+++ b/ldap2pg/role.py
@@ -40,13 +40,11 @@ class Role(object):
     def create(self):
         yield Query(
             'Create %s.' % (self.name,),
-            -1,  # rowcount
             'CREATE ROLE %s WITH %s;' % (self.name, self.options)
         )
         if self.members:
             yield Query(
                 'Add %s members.' % (self.name,),
-                -1,  # rowcount
                 "GRANT %(role)s TO %(members)s;" % dict(
                     members=", ".join(self.members),
                     role=self.name,
@@ -59,7 +57,6 @@ class Role(object):
         if self.options != other.options:
             yield Query(
                 'Update options of %s.' % (self.name,),
-                -1,  # rowcount
                 'ALTER ROLE %s WITH %s;' % (self.name, other.options),
             )
 
@@ -72,7 +69,6 @@ class Role(object):
                 )
                 yield Query(
                     'Add missing %s members.' % (self.name,),
-                    -1,  # rowcount
                     "GRANT %(role)s TO %(members)s;" % dict(
                         members=", ".join(missing),
                         role=self.name,
@@ -86,7 +82,6 @@ class Role(object):
                 )
                 yield Query(
                     'Delete spurious %s members.' % (self.name,),
-                    -1,  # rowcount
                     "REVOKE %(role)s FROM %(members)s;" % dict(
                         members=", ".join(spurious),
                         role=self.name,
@@ -96,7 +91,6 @@ class Role(object):
     def drop(self):
         yield Query(
             'Drop %s.' % (self.name,),
-            -1,  # rowcount
             'DROP ROLE %s;' % (self.name),
         )
 

--- a/ldap2pg/utils.py
+++ b/ldap2pg/utils.py
@@ -3,10 +3,9 @@ def lower1(string):
 
 
 class Query(object):
-    def __init__(self, message, rowcount=-1, *args):
+    def __init__(self, message, *args):
         self.message = message
         self.args = args
-        self.rowcount = rowcount
 
     def __str__(self):
         return self.message

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,9 +6,8 @@ import pytest
 def test_query():
     from ldap2pg.utils import Query
 
-    qry = Query('message', 1, 'SELECT %s;', ('args',))
+    qry = Query('message', 'SELECT %s;', ('args',))
 
-    assert 1 == qry.rowcount
     assert 2 == len(qry.args)
     assert 'message' == str(qry)
 


### PR DESCRIPTION
It's useless with GRANT and REVOKE commands.