### PR TITLE
Configurability updates

### DIFF
--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -147,6 +147,9 @@ def mapping(value):
     # A single mapping from a query to a set of role rules. This function
     # translate random YAML to cannonical schema.
 
+    if not isinstance(value, dict):
+        raise ValueError("Mapping should be a dict.")
+
     if 'ldap' in value:
         value['ldap'] = ldapquery(value['ldap'])
 

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -89,6 +89,9 @@ def ldapquery(value):
 def rolerule(value):
     rule = value
 
+    if isinstance(rule, string_types):
+        rule = dict(names=[rule])
+
     if 'name' in rule:
         rule['names'] = rule.pop('name')
     if 'names' in rule and isinstance(rule['names'], string_types):
@@ -151,7 +154,7 @@ def mapping(value):
         value['roles'] = value['role']
     if 'roles' not in value:
         value['roles'] = []
-    if isinstance(value['roles'], dict):
+    if isinstance(value['roles'], string_types + (dict,)):
         value['roles'] = [value['roles']]
 
     value['roles'] = [rolerule(r) for r in value['roles']]

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -507,8 +507,10 @@ class Configuration(dict):
 
     def read(self, fo, mode):
         payload = yaml.load(fo) or {}
+        if isinstance(payload, list):
+            payload = dict(sync_map=payload)
         if not isinstance(payload, dict):
-            raise ConfigurationError("Configuration file must be a mapping")
+            raise ConfigurationError("Configuration file must be a mapping.")
         payload['world_readable'] = bool(mode & 0o077)
         return payload
 

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -226,6 +226,9 @@ def syncmap(value):
     if ismapping(value):
         value = dict(__common__=[value])
 
+    if not isinstance(value, dict):
+        raise ValueError("Illegal value for sync_map.")
+
     for dbname, ivalue in value.items():
         if isinstance(ivalue, list):
             value[dbname] = ivalue = dict(__common__=ivalue)

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -32,7 +32,6 @@ def wrapped_main(config=None):
     logging_config = config.logging_dict()
     logging.config.dictConfig(logging_config)
 
-    logger.info("Starting ldap2pg %s.", __version__)
     logger.debug("Debug mode enabled.")
 
     try:
@@ -73,6 +72,8 @@ def main():
     config['verbose'] = debug or verbose
     config['color'] = sys.stderr.isatty()
     logging.config.dictConfig(config.logging_dict())
+
+    logger.info("Starting ldap2pg %s.", __version__)
 
     try:
         wrapped_main(config)

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -66,3 +66,11 @@ def test_custom_yaml():
     # And that fixing file mode do the trick.
     chmod('0600', LDAP2PG_CONFIG)
     ldap2pg('--config', LDAP2PG_CONFIG, _env=ldapfree_env)
+
+
+def test_stdin():
+    from sh import ldap2pg
+
+    out = ldap2pg('--config=-', _in="- role: stdinuser")
+
+    assert b'stdinuser' in out.stderr

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -246,6 +246,14 @@ def test_process_syncmap():
     with pytest.raises(ValueError):
         syncmap(raw)
 
+    bad_fixtures = [
+        'string_value',
+        [None],
+    ]
+    for raw in bad_fixtures:
+        with pytest.raises(ValueError):
+            syncmap(raw)
+
 
 def test_process_mapping_grant():
     from ldap2pg.config import mapping

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -268,6 +268,9 @@ def test_process_ldapquery():
 def test_process_rolerule():
     from ldap2pg.config import rolerule
 
+    rule = rolerule('aline')
+    assert 'aline' == rule['names'][0]
+
     rule = rolerule(dict(name='rolname', parent='parent'))
     assert ['rolname'] == rule['names']
     assert ['parent'] == rule['parents']

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -413,14 +413,13 @@ def test_security():
 def test_read_yml():
     from io import StringIO
 
-    from ldap2pg.config import Configuration, ConfigurationError
+    from ldap2pg.config import Configuration
 
     config = Configuration()
 
-    # Deny list file
-    fo = StringIO("- listentry")
-    with pytest.raises(ConfigurationError):
-        config.read(fo, mode=0o0)
+    fo = StringIO("- role: alice")
+    payload = config.read(fo, mode=0o0)
+    assert 'sync_map' in payload
 
     fo = StringIO("entry: value")
     payload = config.read(fo, mode=0o644)


### PR DESCRIPTION
In this PR:

- reads configuration from stdin, ease dynamic configuration in crontabs : `configure | ldap2pg`
- accept `- role: alice` as minimal sync map. (!).