### PR TITLE
Use legacy python-ldap on python2

### DIFF
--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -543,8 +543,9 @@ class Configuration(dict):
                     msg = "Failed to read configuration: %s" % (e,)
                     raise UserError(msg)
 
-        # Now close stdin. To make SASL non-interactive.
-        sys.stdin.close()
+        # Now close stdin. To m(ake SASL non-interactive.
+        if not self.get('debug'):
+            sys.stdin.close()
 
         # Now merge all config sources.
         try:

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -60,6 +60,7 @@ def main():
     verbose = os.environ.get('VERBOSE', '').lower() in {'1', 'y'}
 
     config = Configuration()
+    config['debug'] = debug
     config['verbose'] = debug or verbose
     config['color'] = sys.stderr.isatty()
     logging.config.dictConfig(config.logging_dict())

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,6 @@ classifiers =
 
 [options]
 packages = ldap2pg
-install_requires =
-    psycopg2
-    pyldap
-    pyyaml
-    six
 
 [options.entry_points]
 console_scripts =
@@ -28,7 +23,7 @@ console_scripts =
 
 [bdist_rpm]
 python = /usr/bin/python2
-requires = python-six python-psycopg2 PyYAML
+requires = python-six python-psycopg2 PyYAML python-ldap
 
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,16 @@
+import sys
 from setuptools import setup
 
-setup()
+
+PY3 = sys.version_info > (3,)
+
+
+setup(
+    install_requires=[
+        'psycopg2',
+        'pyldap' if PY3 else 'python-ldap',
+        'pyyaml',
+        'six',
+    ],
+    # Se setup.cfg for metadata and other parameters.
+)

--- a/tests/func/Makefile
+++ b/tests/func/Makefile
@@ -1,3 +1,4 @@
+.ONESHELL:
 default:
 
 rpm:
@@ -13,3 +14,12 @@ clean:
 
 debug:
 	docker-compose exec runner /bin/bash
+
+pytest:
+	cd ../..
+	find . -name "*.pyc" -delete
+# Looks like ./ldaprc is ignored in CentOS7 by libldap and tools. Put it in envs.
+	env $(shell sed 's/^/LDAP/;s/ \+/=/g' ../../ldaprc) pytest tests/func/ $(filter-out $@,$(MAKECMDGOALS))
+
+%:
+	@echo Passing $@ as argument.

--- a/tests/func/docker-compose.yml
+++ b/tests/func/docker-compose.yml
@@ -8,7 +8,11 @@ services:
       LDAP_ADMIN_PASSWORD: fonctionnel
       LDAP_CONFIG_PASSWORD: fonctionnel
       LDAP_TLS_VERIFY_CLIENT: try
+    volumes:
+    - ../../docker/openldap-entrypoint.sh:/ldap2pg-entrypoint.sh
+    - ../../docker/dev-config.ldif:/container/service/slapd/assets/config/bootstrap/ldif/90-config.ldif
     hostname: ldap.ldap2pg.docker
+    entrypoint: /ldap2pg-entrypoint.sh
 
   postgres:
     image: postgres:9.6

--- a/tests/func/entrypoint.sh
+++ b/tests/func/entrypoint.sh
@@ -23,14 +23,10 @@ yum_install() {
 yum_install epel-release
 yum_install \
     cyrus-sasl-md5 \
-    gcc \
     make \
     openldap-clients \
-    openldap-devel\
-    openssl-devel \
     postgresql \
     python \
-    python-devel \
     python2-pip \
     ${NULL-}
 
@@ -40,7 +36,7 @@ psql -tc "SELECT version();"
 
 # Install only ldap2pg and ldap3 package. If other package are required, it's a
 # bug.
-pip2 install --no-deps pyldap --requirement tests/func/requirements.txt
+pip2 install --no-deps --requirement tests/func/requirements.txt
 if ! rpm --query --queryformat= ldap2pg ; then
     yum install -y dist/ldap2pg*.noarch.rpm
     rpm --query --queryformat= ldap2pg

--- a/tests/func/entrypoint.sh
+++ b/tests/func/entrypoint.sh
@@ -46,5 +46,4 @@ if ! rpm --query --queryformat= ldap2pg ; then
     rpm --query --queryformat= ldap2pg
 fi
 
-# Looks like ./ldaprc is ignored in CentOS7 by libldap and tools. Put it in envs.
-env $(sed 's/^/LDAP/;s/ \+/=/g' ldaprc) pytest tests/func/
+make -C tests/func pytest

--- a/tests/func/entrypoint.sh
+++ b/tests/func/entrypoint.sh
@@ -22,6 +22,7 @@ yum_install() {
 
 yum_install epel-release
 yum_install \
+    cyrus-sasl-md5 \
     gcc \
     make \
     openldap-clients \

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -12,8 +12,8 @@ base  ou=IT staff,o="Example, Inc",c=US
 
 
 def test_connect_from_env(mocker):
-    go = mocker.patch('ldap2pg.ldap.gather_options')
-    ldap_initialize = mocker.patch('ldap2pg.ldap.ldap_initialize')
+    go = mocker.patch('ldap2pg.ldap.gather_options', autospec=True)
+    li = mocker.patch('ldap2pg.ldap.ldap_initialize', autospec=True)
 
     from ldap2pg.ldap import connect
 
@@ -27,12 +27,12 @@ def test_connect_from_env(mocker):
 
     assert connexion
     assert go.called is True
-    assert ldap_initialize.called is True
+    assert li.called is True
 
 
 def test_connect_sasl(mocker):
-    go = mocker.patch('ldap2pg.ldap.gather_options')
-    ldap_initialize = mocker.patch('ldap2pg.ldap.ldap_initialize')
+    go = mocker.patch('ldap2pg.ldap.gather_options', autospec=True)
+    li = mocker.patch('ldap2pg.ldap.ldap_initialize', autospec=True)
 
     from ldap2pg.ldap import connect
 
@@ -40,7 +40,7 @@ def test_connect_sasl(mocker):
 
     connect()
 
-    l = ldap_initialize.return_value
+    l = li.return_value
     assert l.sasl_interactive_bind_s.called is True
 
 


### PR DESCRIPTION
This is just to support CentOS packaged python-ldap. I wish pyldap overcome python-ldap!