### PR TITLE
Rename __common__ to a more explicit naming

### DIFF
--- a/ldap2pg.master.yml
+++ b/ldap2pg.master.yml
@@ -96,7 +96,7 @@ acl_dict:
 # entries returned by LDAP.
 sync_map:
   # Special database name to define global mapping
-  __common__:
+  __all__:
   - role:
       # Static rule to create an extra roles not in LDAP. Here we create a
       # ldap_users role in which all roles defined here will belong to. See below.

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -191,8 +191,8 @@ def syncmap(value):
     #
     # A sync map has the following canonical schema:
     #
-    # <__common__|dbname>:
-    #   <__common__|schema>:
+    # <__all__|dbname>:
+    #   <__any__|schema>:
     #   - ldap: <ldapquery>
     #     roles:
     #     - <rolerule>
@@ -234,21 +234,21 @@ def syncmap(value):
     if not value:
         raise ValueError("Empty mapping.")
 
-    if isinstance(value, list):
-        value = dict(__common__=value)
-
     if ismapping(value):
-        value = dict(__common__=[value])
+        value = [value]
+
+    if isinstance(value, list):
+        value = dict(__all__=value)
 
     if not isinstance(value, dict):
         raise ValueError("Illegal value for sync_map.")
 
     for dbname, ivalue in value.items():
-        if isinstance(ivalue, list):
-            value[dbname] = ivalue = dict(__common__=ivalue)
-
         if ismapping(ivalue):
-            value[dbname] = ivalue = dict(__common__=[ivalue])
+            value[dbname] = ivalue = [ivalue]
+
+        if isinstance(ivalue, list):
+            value[dbname] = ivalue = dict(__any__=ivalue)
 
         for schema, maplist in ivalue.items():
             if isinstance(maplist, dict):

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -167,10 +167,10 @@ class SyncManager(object):
         for rule in grant:
             acl = rule.get('acl')
             database = rule.get('database', dbname)
-            if database == '__common__':
+            if database == '__all__':
                 database = AclItem.ALL_DATABASES
             schema = rule.get('schema', schema)
-            if schema == '__common__':
+            if schema == '__any__':
                 schema = None
             pattern = rule.get('role_match')
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -207,7 +207,7 @@ def test_ismapping():
     assert ismapping(dict(roles=[]))
     assert ismapping(dict(role=dict()))
     assert not ismapping([])
-    assert not ismapping(dict(__common__=[]))
+    assert not ismapping(dict(__all__=[]))
 
 
 def test_process_syncmap():
@@ -216,20 +216,20 @@ def test_process_syncmap():
     fixtures = [
         # Canonical case.
         dict(
-            __common__=dict(
-                __common__=[
+            __all__=dict(
+                __any__=[
                     dict(role=dict(name='alice')),
                 ]
             ),
         ),
         # Squeeze list.
         dict(
-            __common__=dict(
-                __common__=dict(role=dict(name='alice')),
+            __all__=dict(
+                __any__=dict(role=dict(name='alice')),
             ),
         ),
         # Squeeze also schema.
-        dict(__common__=dict(role=dict(name='alice'))),
+        dict(__all__=dict(role=dict(name='alice'))),
         # Squeeze also database.
         dict(role=dict(name='alice')),
         # Direct list (this is 1.0 format).
@@ -240,9 +240,9 @@ def test_process_syncmap():
         v = syncmap(raw)
 
         assert isinstance(v, dict)
-        assert '__common__' in v
-        assert '__common__' in v['__common__']
-        maplist = v['__common__']['__common__']
+        assert '__all__' in v
+        assert '__any__' in v['__all__']
+        maplist = v['__all__']['__any__']
         assert 1 == len(maplist)
         assert 'roles' in maplist[0]
 
@@ -509,7 +509,7 @@ def test_load_stdin(mocker):
 
     config.load(argv=[])
 
-    maplist = config['sync_map']['__common__']['__common__']
+    maplist = config['sync_map']['__all__']['__any__']
     assert 1 == len(maplist)
 
 
@@ -532,6 +532,6 @@ def test_load_file(mocker):
     config.load(argv=['--verbose'])
 
     assert 'envpass' == config['ldap']['password']
-    maplist = config['sync_map']['__common__']['__common__']
+    maplist = config['sync_map']['__all__']['__any__']
     assert 1 == len(maplist)
     assert config['verbose'] is True

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -181,7 +181,7 @@ def test_apply_grant_rule_ok(mocker):
         grant=[dict(
             acl='connect',
             database='postgres',
-            schema='__common__',
+            schema='__any__',
             role_attribute='cn',
         )],
         entries=[None, None],
@@ -190,7 +190,7 @@ def test_apply_grant_rule_ok(mocker):
     assert 2 == len(items)
     assert 'alice' == items[0].role
     assert 'postgres' == items[0].dbname
-    # Ensure __common__ schema is mapped to None
+    # Ensure __any__ schema is mapped to None
     assert items[0].schema is None
     assert 'bob' == items[1].role
 
@@ -202,7 +202,7 @@ def test_apply_grant_rule_filter(mocker):
         grant=[dict(
             acl='connect',
             database='postgres',
-            schema='__common__',
+            schema='__any__',
             role_match='*_r',
             roles=['alice_r', 'bob_rw'],
         )],
@@ -224,7 +224,7 @@ def test_apply_grant_rule_nodb(mocker):
     items = list(manager.apply_grant_rules(
         grant=[dict(
             acl='connect',
-            database='__common__', schema='__common__',
+            database='__all__', schema='__any__',
             role_attribute='cn',
         )],
         entries=[None],


### PR DESCRIPTION
Since meaning of `__common__` is different whether its database or schema, we should not use the same word.