### PR TITLE
Default to empty password rather than undefined password

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ follow
 - Add check mode: exits with 1 if changes. Juste like diff.
 - Allow to customize query to inspect roles in cluster.
 - Support old setuptools.
+- Fix undefined LDAP password traceback
 
 
 # ldap2pg 2.0

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -31,7 +31,7 @@ ldap:
   # Set SASL username and enable SASL. env var: LDAPUSER
   # user: saslusername
   # env var: LDAPPASSWORD
-  password: SECRET
+  # password: SECRET
 
 #
 # **Postgres connection**

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -428,7 +428,7 @@ class Configuration(dict):
             'port': 389,
             'binddn': None,
             'user': None,
-            'password': None,
+            'password': '',
             'default_query': {
                 'base': '',
                 'filter': '(objectClass=organizationalRole)',

--- a/ldap2pg/ldap.py
+++ b/ldap2pg/ldap.py
@@ -114,7 +114,7 @@ def gather_options(environ=None, **kw):
         PORT=389,
         BINDDN=None,
         USER=None,
-        PASSWORD=None,
+        PASSWORD='',
     )
 
     environ = environ or os.environ

--- a/tests/func/ldap2pg.yml
+++ b/tests/func/ldap2pg.yml
@@ -26,7 +26,7 @@ ldap:
   # env var: LDAPBINDDN
   binddn: cn=admin,dc=ldap,dc=ldap2pg,dc=docker
   # env var: LDAPPASSWORD
-  password: SECRET
+  # password: SECRET
 
 #
 # **Postgres connection**


### PR DESCRIPTION
Fixes:

    [ldap2pg.ldap        DEBUG] Trying simple bind.
    [ldap2pg.script      ERROR] Unhandled error:
    [ldap2pg.script      ERROR] Traceback (most recent call last):
    [ldap2pg.script      ERROR]   File "/home/bersace/src/dalibo/ldap2pg/ldap2pg/script.py", line 73, in main
    [ldap2pg.script      ERROR]     exit(wrapped_main(config))
    [ldap2pg.script      ERROR]   File "/home/bersace/src/dalibo/ldap2pg/ldap2pg/script.py", line 29, in wrapped_main
    [ldap2pg.script      ERROR]     ldapconn = ldap.connect(**config['ldap'])
    [ldap2pg.script      ERROR]   File "/home/bersace/src/dalibo/ldap2pg/ldap2pg/ldap.py", line 81, in connect
    [ldap2pg.script      ERROR]     l.simple_bind_s(options['BINDDN'], options['PASSWORD'])
    [ldap2pg.script      ERROR]   File "/home/bersace/.local/share/virtualenvs/l2p/lib/python3.5/site-packages/ldap/ldapobject.py", line 41
    7, in simple_bind_s
    [ldap2pg.script      ERROR]     msgid = self.simple_bind(who,cred,serverctrls,clientctrls)
    [ldap2pg.script      ERROR]   File "/home/bersace/.local/share/virtualenvs/l2p/lib/python3.5/site-packages/ldap/ldapobject.py", line 4$
    1, in simple_bind
    [ldap2pg.script      ERROR]     return self._ldap_call(self._l.simple_bind,who,cred,RequestControlTuples(serverctrls),RequestControlTu$
    les(clientctrls))
    [ldap2pg.script      ERROR]   File "/home/bersace/.local/share/virtualenvs/l2p/lib/python3.5/site-packages/ldap/ldapobject.py", line 2$
    4, in _ldap_call
    [ldap2pg.script      ERROR]     result = func(*args,**kwargs)
    [ldap2pg.script      ERROR] TypeError: a bytes-like object is required, not 'NoneType'