### PR TITLE
Use new format instead of printf-style for ACL queries

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ follow
 
 # ldap2pg 2.1 (alpha)
 
+- Breakage: Use format string for ACL queries instead of printf style.
 - Add check mode: exits with 1 if changes. Juste like diff.
 - Allow to customize query to inspect roles in cluster.
 - Support old setuptools.

--- a/docs/config.md
+++ b/docs/config.md
@@ -171,7 +171,8 @@ synchronized: `ldap2pg` will always re-grant the ACL.
 `grant` and `revoke` provide queries to respectively grant and revoke the ACL.
 The query is formatted with three parameters: `database`, `schema` and `role`.
 `database` strictly equals to `CURRENT_DATABASE`, it's just there to help
-putting identifier in the query. `ldap2pg` uses named printf-style formatting.
+putting identifier in the query. `ldap2pg` uses Python's [*Format String
+Syntax*](https://docs.python.org/3.7/library/string.html#formatstrings).
 See example below. In verbose mode, you will see the formatted queries.
 
 Here is an example of a simple ACL which is not schema-aware:
@@ -191,9 +192,9 @@ acl_dict:
       FROM pg_catalog.pg_roles AS r
       JOIN d ON d.grantee = r.oid AND d.priv = 'CONNECT'
     grant: |
-      GRANT CONNECT ON DATABASE %(database)s TO %(role)s;
+      GRANT CONNECT ON DATABASE {database} TO {role};
     revoke: |
-      REVOKE CONNECT ON DATABASE %(database)s FROM %(role)s
+      REVOKE CONNECT ON DATABASE {database} FROM {role}
 ```
 
 Writing `inspect` queries requires a deep knowledge of Postgres internals.
@@ -420,9 +421,9 @@ acl_dict:
       FROM pg_catalog.pg_roles AS r
       JOIN d ON d.grantee = r.oid AND d.priv = 'CONNECT'
     grant: |
-      GRANT CONNECT ON DATABASE %(database)s TO %(role)s;
+      GRANT CONNECT ON DATABASE {database} TO {role};
     revoke: |
-      REVOKE CONNECT ON DATABASE %(database)s FROM %(role)s
+      REVOKE CONNECT ON DATABASE {database} FROM {role}
 
 sync_map:
 - role:

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -42,7 +42,7 @@ roles in different sets with different policies.
 The query must return a set of row with the rolname as first column, an array
 with the name of all members of the role as second column, followed by columns
 defined in `{options}` template variable. `{options}` contains the ordered
-columns of managed role options as supported by `ldap2pg`. `ldpa2pg` user
+columns of managed role options as supported by `ldap2pg`. `ldpa2pg` uses
 Python's [*Format String
 Syntax*](https://docs.python.org/3.7/library/string.html#formatstrings). Only
 `options` substitution is available. `%` is safe.

--- a/ldap2pg/acl.py
+++ b/ldap2pg/acl.py
@@ -22,7 +22,7 @@ class Acl(object):
         return Query(
             "Grant %s." % (item,),
             item.dbname,
-            self.grant_sql % dict(
+            self.grant_sql.format(
                 database=item.dbname,
                 schema=item.schema,
                 role=item.role,
@@ -33,7 +33,7 @@ class Acl(object):
         return Query(
             "Revoke %s." % (item,),
             item.dbname,
-            self.revoke_sql % dict(
+            self.revoke_sql.format(
                 database=item.dbname,
                 schema=item.schema,
                 role=item.role,

--- a/tests/func/ldap2pg.yml
+++ b/tests/func/ldap2pg.yml
@@ -66,7 +66,7 @@ acl_dict:
       LEFT OUTER JOIN acls ON acls.grantee = 0
       WHERE acls.grantee IS NULL;
     revoke: |
-      REVOKE CONNECT ON DATABASE %(database)s FROM %(role)s
+      REVOKE CONNECT ON DATABASE {database} FROM {role}
 
   connect:
     inspect: |
@@ -81,9 +81,9 @@ acl_dict:
       FROM pg_catalog.pg_roles AS r
       JOIN d ON d.grantee = r.oid AND d.priv = 'CONNECT'
     grant: |
-      GRANT CONNECT ON DATABASE %(database)s TO %(role)s;
+      GRANT CONNECT ON DATABASE {database} TO {role};
     revoke: |
-      REVOKE CONNECT ON DATABASE %(database)s FROM %(role)s
+      REVOKE CONNECT ON DATABASE {database} FROM {role}
 
 
 #

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -31,7 +31,7 @@ def test_items():
 def test_grant():
     from ldap2pg.acl import Acl, AclItem
 
-    acl = Acl(name='connect', grant='GRANT %(database)s TO %(role)s;')
+    acl = Acl(name='connect', grant='GRANT {database} TO {role};')
     item = AclItem(acl=acl.name, dbname='backend', schema=None, role='daniel')
     qry = acl.grant(item)
 
@@ -42,7 +42,7 @@ def test_grant():
 def test_revoke():
     from ldap2pg.acl import Acl, AclItem
 
-    acl = Acl(name='connect', revoke='REVOKE %(database)s FROM %(role)s;')
+    acl = Acl(name='connect', revoke='REVOKE {database} FROM {role};')
     item = AclItem(acl=acl.name, dbname='backend', schema=None, role='daniel')
     qry = acl.revoke(item)
 

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -318,7 +318,7 @@ def test_diff_acls(mocker):
     from ldap2pg.acl import Acl, AclItem
     from ldap2pg.manager import SyncManager
 
-    acl = Acl(name='connect', revoke='REVOKE %(role)s', grant='GRANT %(role)s')
+    acl = Acl(name='connect', revoke='REVOKE {role}', grant='GRANT {role}')
     nogrant = Acl(name='nogrant', revoke='REVOKE')
     norvk = Acl(name='norvk', grant='GRANT')
     m = SyncManager(acl_dict={a.name: a for a in [acl, nogrant, norvk]})


### PR DESCRIPTION
I prefer to break early instead of having trouble with multiple format syntax in config file.

`.format` must be prefered over printf-style for input because it's easier to use `%` SQL operator with it.