### PR TITLE
Add __all__ meta-schema

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -294,9 +294,11 @@ inherited from the synchronization map. The special database name `__all__`
 means **all** databases. `ldap2pg` will loop every databases in the cluster but
 `template0` and apply the `grant` or `revoke` query on it.
 
-In the same way, `schema` allows to scope the grant to a schema, regardless of
-database. If `schema` is `__any__` or `null`, the `grant` or `revoke` query will
-receive `None` as schema.
+In the same way, `schema` allows to scope the grant to one or more schema,
+regardless of database. If `schema` is `__any__` or `null`, the `grant` or
+`revoke` query will receive `None` as schema. If `schema` is `__all__`,
+`ldap2pg` will loop all schema including `information_scema` and yield a revoke
+or grant on each.
 
 `role` or `roles` keys allow to specify statically one or more role to grant the
 ACL to. `role` must be a string or a list of strings. Referenced roles must be

--- a/fixtures/postgres.sh
+++ b/fixtures/postgres.sh
@@ -31,10 +31,34 @@ CREATE DATABASE legacy;
 
 -- daniel was a backend developer and is now a frontend. He add access to
 -- backend database. We have to revoke.
+REVOKE CONNECT ON DATABASE frontend FROM daniel;
 GRANT CONNECT ON DATABASE backend TO daniel;
 EOSQL
 
 # Create a legacy table owned by a legacy user.
 PGDATABASE=legacy PGUSER=oscar psql <<EOSQL
 CREATE TABLE keepme (id serial PRIMARY KEY);
+EOSQL
+
+# grant some privileges to daniel, to be revoked.
+PGDATABASE=backend psql <<EOSQL
+CREATE SCHEMA backend;
+GRANT SELECT ON ALL TABLES IN SCHEMA backend TO daniel;
+GRANT USAGE ON SCHEMA backend TO daniel;
+GRANT SELECT ON ALL TABLES IN SCHEMA information_schema TO daniel;
+GRANT USAGE ON SCHEMA information_schema TO daniel;
+EOSQL
+
+# Ensure daniel has no privileges on frontend, for grant.
+PGDATABASE=frontend psql <<EOSQL
+CREATE SCHEMA frontend;
+CREATE TABLE frontend.table1 (id INTEGER);
+CREATE SCHEMA empty;
+
+REVOKE SELECT ON ALL TABLES IN SCHEMA empty FROM daniel;
+REVOKE USAGE ON SCHEMA empty FROM daniel;
+REVOKE SELECT ON ALL TABLES IN SCHEMA frontend FROM daniel;
+REVOKE USAGE ON SCHEMA frontend FROM daniel;
+REVOKE SELECT ON ALL TABLES IN SCHEMA information_schema FROM daniel;
+REVOKE USAGE ON SCHEMA information_schema FROM daniel;
 EOSQL

--- a/ldap2pg/acl.py
+++ b/ldap2pg/acl.py
@@ -2,6 +2,12 @@ from .psql import Query
 from .utils import AllDatabases
 
 
+class AllSchemas(object):
+    # Simple object to represent schema wildcard.
+    def __repr__(self):
+        return '__ALL_SCHEMAS__'
+
+
 class Acl(object):
     def __init__(self, name, inspect=None, grant=None, revoke=None):
         self.name = name
@@ -43,6 +49,7 @@ class Acl(object):
 
 class AclItem(object):
     ALL_DATABASES = AllDatabases()
+    ALL_SCHEMAS = AllSchemas()
 
     @classmethod
     def from_row(cls, *args):
@@ -77,15 +84,22 @@ class AclItem(object):
 
     def expand(self, databases):
         if self.dbname is self.ALL_DATABASES:
-            for dbname in databases:
+            dbnames = databases.keys()
+        else:
+            dbnames = [self.dbname]
+
+        for dbname in dbnames:
+            if self.schema is self.ALL_SCHEMAS:
+                schemas = databases[dbname]
+            else:
+                schemas = [self.schema]
+            for schema in schemas:
                 yield self.__class__(
                     acl=self.acl,
                     dbname=dbname,
-                    schema=self.schema,
+                    schema=schema,
                     role=self.role,
                 )
-        else:
-            yield self
 
 
 class AclSet(set):

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -195,7 +195,7 @@ def syncmap(value):
     # A sync map has the following canonical schema:
     #
     # <__all__|dbname>:
-    #   <__any__|schema>:
+    #   <__all__|__any__|schema>:
     #   - ldap: <ldapquery>
     #     roles:
     #     - <rolerule>

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -60,6 +60,14 @@ class SyncManager(object):
         for row in psql(select):
             yield row[0]
 
+    def fetch_schema_list(self, psql):
+        select = """
+        SELECT nspname FROM pg_catalog.pg_namespace
+        WHERE nspname NOT LIKE 'pg_%' AND nspname != 'public' ORDER BY 1;
+        """.strip().replace(8 * ' ', '')
+        for row in psql(select):
+            yield row[0]
+
     def fetch_pg_roles(self, psql):
         row_cols = ['rolname'] + list(RoleOptions.COLUMNS_MAP.values())
         row_cols = ['role.%s' % (r,) for r in row_cols]
@@ -155,12 +163,17 @@ class SyncManager(object):
     def apply_grant_rules(self, grant, dbname=None, schema=None, entries=[]):
         for rule in grant:
             acl = rule.get('acl')
+
             database = rule.get('database', dbname)
             if database == '__all__':
                 database = AclItem.ALL_DATABASES
+
             schema = rule.get('schema', schema)
-            if schema == '__any__':
+            if schema == '__all__':
+                schema = AclItem.ALL_SCHEMAS
+            elif schema == '__any__':
                 schema = None
+
             pattern = rule.get('role_match')
 
             for entry in entries:
@@ -184,6 +197,10 @@ class SyncManager(object):
             databases = list(self.fetch_database_list(psql))
             rows = self.fetch_pg_roles(psql)
             pgroles = RoleSet(self.process_pg_roles(rows))
+
+        schemas = {k: [] for k in databases}
+        for dbname, psql in self.psql.itersessions(databases):
+            schemas[dbname] = list(self.fetch_schema_list(psql))
 
         # Inspect ACLs
         pgacls = AclSet()
@@ -221,7 +238,7 @@ class SyncManager(object):
 
         logger.debug("LDAP inspection completed. Post processing.")
         ldaproles.resolve_membership()
-        ldapacls = AclSet(list(ldapacls.expanditems(databases)))
+        ldapacls = AclSet(list(ldapacls.expanditems(schemas)))
 
         return databases, pgroles, pgacls, ldaproles, ldapacls
 

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -286,7 +286,11 @@ class SyncManager(object):
                 if self.dry:
                     logger.debug("Would execute: %s", sql)
                 else:
-                    psql(sql)
+                    try:
+                        psql(sql)
+                    except Exception as e:
+                        msg = "Error while executing SQL query:\n%s" % (e,)
+                        raise UserError(msg)
         logger.debug("Generated %d querie(s).", count)
 
         if not count:

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -188,14 +188,12 @@ class SyncManager(object):
         # Inspect ACLs
         pgacls = AclSet()
         for name, acl in sorted(self.acl_dict.items()):
+            if not acl.inspect:
+                logger.warn("Can't inspect ACL %s: query not defined.", acl)
+                continue
+
             logger.debug("Searching items of ACL %s.", acl)
             for dbname, psql in self.psql.itersessions(databases):
-                if not acl.inspect:
-                    logger.warn(
-                        "Can't inspect ACL %s: query not defined.", acl,
-                    )
-                    continue
-
                 rows = psql(acl.inspect)
                 for aclitem in self.process_pg_acl_items(name, dbname, rows):
                     logger.debug("Found ACL item %s.", aclitem)

--- a/ldap2pg/utils.py
+++ b/ldap2pg/utils.py
@@ -7,7 +7,7 @@ from fnmatch import fnmatch
 PY2 = sys.version_info < (3,)
 
 if PY2:
-    string_types = (str, unicode)
+    string_types = (str, unicode)  # noqa
 else:
     string_types = (str,)
 

--- a/tests/func/ldap2pg.acl.yml
+++ b/tests/func/ldap2pg.acl.yml
@@ -1,0 +1,106 @@
+# File dedicated to test real ACL use cases. This allow to test documentation
+# exemple.
+
+acl_dict:
+  # CONNECT ACL on database
+  connect:
+    inspect: |
+      WITH d AS (
+          SELECT
+              (aclexplode(datacl)).grantee AS grantee,
+              (aclexplode(datacl)).privilege_type AS priv
+          FROM pg_catalog.pg_database
+          WHERE datname = current_database()
+      )
+      SELECT NULL as namespace, r.rolname
+      FROM pg_catalog.pg_roles AS r
+      JOIN d ON d.grantee = r.oid AND d.priv = 'CONNECT'
+    grant: |
+      GRANT CONNECT ON DATABASE {database} TO {role};
+    revoke: |
+      REVOKE CONNECT ON DATABASE {database} FROM {role};
+
+  # CONNECT ACL on PUBLIC role database
+  public:
+    inspect: |
+      -- Returns public if no ACLs are defined in this database.
+      WITH
+      acls AS (
+          SELECT
+              (aclexplode(datacl)).grantee AS grantee,
+              (aclexplode(datacl)).privilege_type AS priv
+          FROM pg_catalog.pg_database
+          WHERE datname = current_database()
+      ),
+      static AS (
+          SELECT NULL AS namespace, 'public' AS rolname
+      )
+      SELECT static.* FROM static
+      LEFT OUTER JOIN acls ON acls.grantee = 0
+      WHERE acls.grantee IS NULL;
+    revoke: |
+      REVOKE CONNECT ON DATABASE {database} FROM {role}
+
+  # SELECT on TABLES
+  ro:
+    inspect: |
+      WITH
+        nsp AS (
+          -- All namespace and role having grant on it, and array of available
+          -- relations in the namespace.
+          SELECT
+            nsp.oid, nsp.nspname,
+            (aclexplode(nspacl)).grantee AS grantee,
+            (aclexplode(nspacl)).privilege_type,
+            ARRAY(SELECT UNNEST(array_agg(rel.relname)) ORDER BY 1) AS relname
+          FROM pg_catalog.pg_namespace nsp
+          LEFT OUTER JOIN pg_catalog.pg_class rel
+            ON rel.relnamespace = nsp.oid AND relkind IN ('r', 'v')
+          WHERE nsp.nspname NOT LIKE 'pg_%'
+          GROUP BY 1, 2, 3, 4
+        ),
+        rel AS (
+          -- All namespace, role and relation privilege granted to what relation
+          -- in the namespace.
+          SELECT
+            table_schema as "schema",
+            grantee, privilege_type,
+            -- Aggregate the relation grant for this privilege.
+            ARRAY(SELECT UNNEST(array_agg(table_name::name)) ORDER BY 1) as tables
+          FROM information_schema.role_table_grants
+          GROUP BY 1, 2, 3
+        )
+
+      -- Now list all users who have USAGE on schema and SELECT to **all**
+      -- relations in the schema.
+      SELECT nsp.nspname, rol.rolname
+      FROM nsp
+      JOIN pg_catalog.pg_roles rol ON rol.oid = nsp.grantee
+      LEFT OUTER JOIN rel AS select_
+        ON select_.privilege_type = 'SELECT' AND
+           select_."schema" = nsp.nspname AND
+           select_.grantee = rol.rolname
+      WHERE nsp.privilege_type = 'USAGE'
+            -- Here, compare arrays to ensure SELECT grant is for all relation in
+            -- namespace.
+            AND coalesce(select_.tables, ARRAY[NULL]::name[]) = nsp.relname
+      ORDER BY 1, 2;
+    grant: |
+      GRANT USAGE ON SCHEMA {schema} TO {role};
+      GRANT SELECT ON ALL TABLES IN SCHEMA {schema} TO {role};
+    revoke: |
+      REVOKE SELECT ON ALL TABLES IN SCHEMA {schema} FROM {role};
+      REVOKE USAGE ON SCHEMA {schema} FROM {role};
+
+sync_map:
+- roles: [alice, daniel, oscar]
+- grant:
+    role: daniel
+    acl: connect
+    database: frontend
+    schema: __any__
+- grant:
+    role: daniel
+    acl: ro
+    database: frontend
+    schema: __all__

--- a/tests/func/ldap2pg.yml
+++ b/tests/func/ldap2pg.yml
@@ -44,30 +44,11 @@ postgres:
   # List of glob patterns to exclude external roles.
   blacklist: [postgres, pg_*]
 
+
 #
 # **ACL**
 #
 acl_dict:
-  public:
-    inspect: |
-      -- Returns public if no ACLs are defined in this database.
-      WITH
-      acls AS (
-          SELECT
-              (aclexplode(datacl)).grantee AS grantee,
-              (aclexplode(datacl)).privilege_type AS priv
-          FROM pg_catalog.pg_database
-          WHERE datname = current_database()
-      ),
-      static AS (
-          SELECT NULL AS namespace, 'public' AS rolname
-      )
-      SELECT static.* FROM static
-      LEFT OUTER JOIN acls ON acls.grantee = 0
-      WHERE acls.grantee IS NULL;
-    revoke: |
-      REVOKE CONNECT ON DATABASE {database} FROM {role}
-
   connect:
     inspect: |
       WITH d AS (
@@ -83,7 +64,7 @@ acl_dict:
     grant: |
       GRANT CONNECT ON DATABASE {database} TO {role};
     revoke: |
-      REVOKE CONNECT ON DATABASE {database} FROM {role}
+      REVOKE CONNECT ON DATABASE {database} FROM {role};
 
 
 #

--- a/tests/func/test_acl.py
+++ b/tests/func/test_acl.py
@@ -1,0 +1,34 @@
+# Test order matters.
+
+from __future__ import unicode_literals
+
+
+def test_dry_run(dev, ldap, psql):
+    from sh import ldap2pg
+
+    ldap2pg(c='tests/func/ldap2pg.acl.yml')
+
+
+def test_check_mode(dev, ldap, psql):
+    from sh import ldap2pg
+
+    ldap2pg('--check', c='tests/func/ldap2pg.acl.yml', _ok_code=1)
+
+
+def test_real_mode(dev, ldap, psql):
+    from sh import ldap2pg
+
+    # synchronize all
+    ldap2pg('-N', c='tests/func/ldap2pg.acl.yml')
+    # Ensure ACL inspects are ok
+    ldap2pg('-C', c='tests/func/ldap2pg.acl.yml')
+
+    # Create a new table.
+    psql(d='frontend', c='CREATE TABLE frontend.nt(id INTEGER PRIMARY KEY);')
+    # Ensure GRANT ON ALL TABLES IN SCHEMA must be reexecuted.
+    ldap2pg('-C', c='tests/func/ldap2pg.acl.yml', _ok_code=1)
+
+    # resynchronize all
+    ldap2pg('-N', c='tests/func/ldap2pg.acl.yml')
+    # Ensure ACL inspects are ok again
+    ldap2pg('-C', c='tests/func/ldap2pg.acl.yml')

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -53,8 +53,19 @@ def test_revoke():
 def test_expand():
     from ldap2pg.acl import AclItem
 
-    item = AclItem(acl='ro', dbname=AclItem.ALL_DATABASES)
-    items = list(item.expand(['postgres', 'template1']))
+    item = AclItem(
+        acl=['ro'], dbname=AclItem.ALL_DATABASES, schema=AclItem.ALL_SCHEMAS,
+    )
+
+    assert repr(item.schema)
+
+    items = sorted(
+        item.expand(dict(
+            postgres=['information_schema'],
+            template1=['information_schema'],
+        )),
+        key=lambda x: x.dbname,
+    )
 
     assert 2 == len(items)
     assert 'postgres' == items[0].dbname


### PR DESCRIPTION
Since looping on schema can be quite hard and error-prone, I suggest to add a `__all__` value for `schema` attribute of `grant` rule. This allow ldap2pg to manage the loop of schema.

`pg_*` are hidden in the code, but not `information_schema`.