### PR TITLE
Manage unknown attribute in LDAP entry

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,11 @@ follow
 [merged Pull request pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
 
+# ldap2pg 3.1 (unreleased)
+
+- Fix unhandled exception when attribute does not exists in LDAP.
+
+
 # ldap2pg 3.0 (unreleased)
 
 - Breakage: Use Python `{}` format string for ACL queries instead of named

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -212,7 +212,7 @@ class SyncManager(object):
                     role = role.lower()
                     if pattern and not fnmatch(role, pattern):
                         logger.debug(
-                            "Don't grand %s to %s not matching %s",
+                            "Don't grant %s to %s not matching %s",
                             acl, role, pattern,
                         )
                         continue

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 from io import StringIO
 
+import pytest
+
 
 RC_SAMPLE = """
 # Comment
@@ -119,3 +121,16 @@ def test_parse_rc():
     assert 'ldap://host ldaps://host' == items[0].value
     assert '<stdin>' == items[0].filename
     assert 3 == items[0].lineno
+
+
+def test_get_ldap_attr():
+    from ldap2pg.manager import get_ldap_attribute
+
+    with pytest.raises(ValueError):
+        list(get_ldap_attribute(entry=('dn', {}), attribute='pouet'))
+
+    with pytest.raises(ValueError):
+        list(get_ldap_attribute(
+            entry=('dn', {'cn': ['cn=pouet']}),
+            attribute='cn.pouet',
+        ))


### PR DESCRIPTION
This should be an error in configuration file. But we can't check it at
validation.

Fixes:

    Unhandled error:
    Traceback (most recent call last):
      File "/home/bersace/src/dalibo/ldap2pg/ldap2pg/manager.py", line 26, in get_ldap_attribute
        values = attributes[path[0]]
    KeyError: 'members'