### PR TITLE
Update documentation links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 Swiss-army knife to synchronize Postgres roles and ACLs from any LDAP directory.
 
-.. _documentation: http://ldap2pg.readthedocs.io/
+.. _documentation: https://ldap2pg.readthedocs.io/en/latest/
 .. _license:       https://opensource.org/licenses/postgresql
 
 
@@ -96,5 +96,5 @@ More details can be found in documentation_.
    :alt: Version on PyPI
 
 .. |RTD| image:: https://readthedocs.org/projects/ldap2pg/badge/?version=latest
-   :target: http://ldap2pg.readthedocs.io/en/latest/?badge=latest
+   :target: https://ldap2pg.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,7 +32,7 @@ optional arguments:
   -V, --version         show version and exit
 
 ldap2pg requires a configuration file to describe LDAP queries and role
-mappings. See https://ldap2pg.readthedocs.org/ for further details. By
+mappings. See https://ldap2pg.readthedocs.io/en/latest/ for further details. By
 default, ldap2pg runs in dry mode.
 ```
 
@@ -236,7 +236,7 @@ A mapping is a dict with three kind of rules: `ldap`, `roles` and `grant`.
 `ldap` entry is optionnal, however either one of `roles` or `grant` is required.
 Here is a sample:
 
-``` yaml 
+``` yaml
 - ldap:
     base: ou=people,dc=ldap,dc=ldap2pg,dc=docker
     filter: "(objectClass=organizationalRole)"

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -5,7 +5,7 @@
 # password in it.
 #
 # See also full documenation on how to configure ldap2pg at
-# http://ldap2pg.readthedocs.io/en/latest/config/.
+# https://ldap2pg.readthedocs.io/en/latest/config/.
 
 # Colorization. env var: COLOR=<anything>
 color: yes

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -535,7 +535,7 @@ class Configuration(dict):
     EPILOG = """\
 
     ldap2pg requires a configuration file to describe LDAP queries and role
-    mappings. See https://ldap2pg.readthedocs.org/ for further details.
+    mappings. See https://ldap2pg.readthedocs.io/en/latest/ for further details.
 
     By default, ldap2pg runs in dry mode.
     """.replace(4 * ' ', '')


### PR DESCRIPTION
1. Updated ldap2pg.readthedocs.org to ldap2pg.readthedocs.io
2. Using https links everywhere