### PR TITLE
Distinct ACL types, first batch

### DIFF
--- a/ldap2pg/acl.py
+++ b/ldap2pg/acl.py
@@ -39,7 +39,7 @@ class Acl(object):
             else:
                 schemas = [item.schema]
             for schema in schemas:
-                yield item.copy(dbname=dbname, schema=schema)
+                yield item.copy(acl=self.name, dbname=dbname, schema=schema)
 
     def grant(self, item):
         return Query(
@@ -100,14 +100,6 @@ class AclItem(object):
     def as_tuple(self):
         return (self.acl, self.dbname, self.schema, self.role)
 
-    def expandaliases(self, aliases):
-        for acl in aliases[self.acl]:
-            yield self.__class__(
-                acl,
-                self.dbname, self.schema, self.role,
-                self.full,
-            )
-
     def copy(self, **kw):
         return self.__class__(**dict(dict(
             acl=self.acl,
@@ -119,8 +111,9 @@ class AclItem(object):
 
 
 class AclSet(set):
-    def expanditems(self, acls, databases):
+    def expanditems(self, aliases, acl_dict, databases):
         for item in self:
-            acl = acls[item.acl]
-            for expansion in acl.expand(item, databases):
-                yield expansion
+            for aclname in aliases[item.acl]:
+                acl = acl_dict[aclname]
+                for expansion in acl.expand(item, databases):
+                    yield expansion

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -166,7 +166,7 @@ def postprocess_acl_options(self):
     )
     # Now split acls by type
     self['acl_dict'] = dict([
-        (k, Acl(k, **v)) for k, v in acls.items()
+        (k, Acl.factory(k, **v)) for k, v in acls.items()
         if isinstance(v, dict)]
     )
     self['acl_groups'] = dict([

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -240,12 +240,16 @@ class SyncManager(object):
                         aclitem.dbname,)
                     raise UserError(msg)
                 logger.debug("Found ACL item %s in LDAP.", aclitem)
-                for realitem in aclitem.expandaliases(self.acl_aliases):
-                    ldapacls.add(realitem)
+                ldapacls.add(aclitem)
 
         logger.debug("LDAP inspection completed. Post processing.")
         ldaproles.resolve_membership()
-        ldapacls = AclSet(list(ldapacls.expanditems(self.acl_dict, schemas)))
+        expanded_acls = ldapacls.expanditems(
+            aliases=self.acl_aliases,
+            acl_dict=self.acl_dict,
+            databases=schemas,
+        )
+        ldapacls = AclSet(list(expanded_acls))
 
         return databases, pgroles, pgacls, ldaproles, ldapacls
 

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -245,7 +245,7 @@ class SyncManager(object):
 
         logger.debug("LDAP inspection completed. Post processing.")
         ldaproles.resolve_membership()
-        ldapacls = AclSet(list(ldapacls.expanditems(schemas)))
+        ldapacls = AclSet(list(ldapacls.expanditems(self.acl_dict, schemas)))
 
         return databases, pgroles, pgacls, ldaproles, ldapacls
 

--- a/ldap2pg/validators.py
+++ b/ldap2pg/validators.py
@@ -33,13 +33,15 @@ def ldapquery(value):
 
 
 def acl(raw):
-    allowed_keys = set(['grant', 'inspect', 'revoke'])
+    allowed_keys = set(['grant', 'inspect', 'revoke', 'type'])
     defined_keys = set(raw.keys())
     spurious_keys = defined_keys - allowed_keys
 
     if spurious_keys:
         msg = "Unknown keys %s" % (', '.join(spurious_keys),)
         raise ValueError(msg)
+
+    raw.setdefault('type', 'nspacl')
 
     return raw
 

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -51,19 +51,25 @@ def test_revoke():
 
 
 def test_expand():
-    from ldap2pg.acl import AclItem
+    from ldap2pg.acl import Acl, AclSet, AclItem
 
+    acl = Acl('usage', grant='GRANT USAGE')
     item = AclItem(
-        acl=['ro'], dbname=AclItem.ALL_DATABASES, schema=AclItem.ALL_SCHEMAS,
+        acl='usage', dbname=AclItem.ALL_DATABASES, schema=AclItem.ALL_SCHEMAS,
     )
 
     assert repr(item.schema)
 
+    set_ = AclSet([item])
+
     items = sorted(
-        item.expand(dict(
-            postgres=['information_schema'],
-            template1=['information_schema'],
-        )),
+        set_.expanditems(
+            acls={acl.name: acl},
+            databases=dict(
+                postgres=['information_schema'],
+                template1=['information_schema'],
+            ),
+        ),
         key=lambda x: x.dbname,
     )
 

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -64,7 +64,8 @@ def test_expand():
 
     items = sorted(
         set_.expanditems(
-            acls={acl.name: acl},
+            aliases=dict(usage=['usage']),
+            acl_dict={acl.name: acl},
             databases=dict(
                 postgres=['information_schema'],
                 template1=['information_schema'],

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -51,9 +51,9 @@ def test_revoke():
 
 
 def test_expand():
-    from ldap2pg.acl import Acl, AclSet, AclItem
+    from ldap2pg.acl import NspAcl, AclSet, AclItem
 
-    acl = Acl('usage', grant='GRANT USAGE')
+    acl = NspAcl('usage', grant='GRANT USAGE')
     item = AclItem(
         acl='usage', dbname=AclItem.ALL_DATABASES, schema=AclItem.ALL_SCHEMAS,
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -409,7 +409,7 @@ def test_acl_options():
 
     config_v33 = dict(
         acl_dict=dict(
-            select=dict(inspect='INSPECT'),
+            select=dict(type='nspacl', inspect='INSPECT'),
         ),
         acl_groups=dict(ro=['select'])
     )
@@ -417,7 +417,7 @@ def test_acl_options():
     postprocess_acl_options(config_v33)
 
     config_v34 = dict(acls=dict(
-        select=dict(inspect='INSPECT'),
+        select=dict(type='nspacl', inspect='INSPECT'),
         ro=['select'],
     ))
 

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -331,12 +331,12 @@ def test_inspect_acls(mocker):
     la = mocker.patch(mod + 'SyncManager.apply_grant_rules', autospec=True)
 
     from ldap2pg.manager import SyncManager, AclItem
-    from ldap2pg.acl import Acl
+    from ldap2pg.acl import NspAcl
     from ldap2pg.utils import make_group_map
 
     acl_dict = dict(
-        noinspect=Acl(name='noinspect'),
-        ro=Acl(name='ro', inspect='SQL'),
+        noinspect=NspAcl(name='noinspect'),
+        ro=NspAcl(name='ro', inspect='SQL'),
     )
     pa.return_value = [AclItem('ro', 'postgres', None, 'alice')]
     la.return_value = [AclItem('ro', 'postgres', None, 'alice')]


### PR DESCRIPTION
ACL type are `datacl`, `nspacl` or `defacl` and other can follow.

Until now, the variation is handled with a hack to ignore schema when it's pointless with some limitations : user muste specify `schema: __any__` to avoid duplicated `GRANT`  in sync_map ; ACL groups can't mix properly different kind of ACL : schema ACL requires `schema: __all__` while database ACL should have `schema: __any__`.