### PR TITLE
Default ACL updates

### DIFF
--- a/fixtures/postgres.sh
+++ b/fixtures/postgres.sh
@@ -9,8 +9,7 @@ DROP DATABASE IF EXISTS olddb;
 DROP DATABASE IF EXISTS appdb;
 DELETE FROM pg_catalog.pg_auth_members;
 DELETE FROM pg_catalog.pg_authid WHERE rolname != 'postgres' AND rolname NOT LIKE 'pg_%';
-REVOKE TEMPORARY ON DATABASE postgres FROM PUBLIC;
-REVOKE TEMPORARY ON DATABASE template1 FROM PUBLIC;
+UPDATE pg_database SET datacl = NULL WHERE datallowconn IS TRUE;
 
 -- Create role as it should be. for NOOP
 CREATE ROLE app WITH NOLOGIN;

--- a/fixtures/postgres.sh
+++ b/fixtures/postgres.sh
@@ -3,6 +3,14 @@
 # Dév fixture initializing a cluster with a «previous state», needing a lot of
 # synchronization. See openldap-data.ldif for details.
 
+for d in template1 postgres ; do
+    psql -v ON_ERROR_STOP=1 $d <<EOSQL
+UPDATE pg_namespace SET nspacl = NULL WHERE nspname NOT LIKE 'pg_%';
+GRANT USAGE ON SCHEMA information_schema TO PUBLIC;
+GRANT USAGE, CREATE ON SCHEMA public TO PUBLIC;
+EOSQL
+done
+
 psql -v ON_ERROR_STOP=1 <<EOSQL
 -- Purge everything.
 DROP DATABASE IF EXISTS olddb;

--- a/fixtures/postgres.sh
+++ b/fixtures/postgres.sh
@@ -11,10 +11,19 @@ GRANT USAGE, CREATE ON SCHEMA public TO PUBLIC;
 EOSQL
 done
 
-psql -v ON_ERROR_STOP=1 <<EOSQL
+psql -v ON_ERROR_STOP=1 <<'EOSQL'
 -- Purge everything.
 DROP DATABASE IF EXISTS olddb;
 DROP DATABASE IF EXISTS appdb;
+DO $$
+  DECLARE r record;
+BEGIN
+  FOR r IN SELECT rolname FROM pg_catalog.pg_roles WHERE rolname NOT LIKE 'pg_%' AND rolname <> 'postgres'
+  LOOP
+    EXECUTE 'DROP OWNED BY ' || r.rolname;
+  END LOOP;
+END$$;
+
 DELETE FROM pg_catalog.pg_auth_members;
 DELETE FROM pg_catalog.pg_authid WHERE rolname != 'postgres' AND rolname NOT LIKE 'pg_%';
 UPDATE pg_database SET datacl = NULL WHERE datallowconn IS TRUE;

--- a/ldap2pg/defaults.py
+++ b/ldap2pg/defaults.py
@@ -63,7 +63,7 @@ _defacl_tpl = dict(
 
 _nspacl_tpl = dict(
     type="nspacl",
-    inspect="""\
+    inspect="""
     WITH grants AS (
       SELECT
         nspname,
@@ -79,7 +79,7 @@ _nspacl_tpl = dict(
     WHERE (grantee = 0 OR rolname IS NOT NULL)
       AND grants.priv = '%(privilege)s'
     ORDER BY 1, 2;
-    """.replace(' ' * 4, ''),
+    """.replace('\n    ', '\n').strip(),
     grant="GRANT %(privilege)s ON SCHEMA {schema} TO {role};",
     revoke="REVOKE %(privilege)s ON SCHEMA {schema} FROM {role};",
 )

--- a/ldap2pg/defaults.py
+++ b/ldap2pg/defaults.py
@@ -248,6 +248,7 @@ def make_well_known_acls():
     acls = dict([
         make_acl(_datacl_tpl, '__connect__', None, 'CONNECT'),
         make_acl(_datacl_tpl, '__temporary__', None, 'TEMPORARY'),
+        make_acl(_nspacl_tpl, '__create_on_schema__', None, 'CREATE'),
         make_acl(_nspacl_tpl, '__usage_on_schema__', None, 'USAGE'),
         make_acl(_defacl_tpl, '__usage_on_types__', 'T', 'USAGE'),
     ])

--- a/ldap2pg/defaults.py
+++ b/ldap2pg/defaults.py
@@ -234,6 +234,7 @@ def make_rel_acls(privilege, t, namefmt='__%(privilege)s_on_%(type)s__'):
 def make_well_known_acls():
     acls = dict([
         make_acl(_datacl_tpl, '__connect__', None, 'CONNECT'),
+        make_acl(_datacl_tpl, '__temporary__', None, 'TEMPORARY'),
         make_acl(_nspacl_tpl, '__usage_on_schema__', None, 'USAGE'),
         make_acl(_defacl_tpl, '__usage_on_types__', 'T', 'USAGE'),
     ])

--- a/ldap2pg/defaults.py
+++ b/ldap2pg/defaults.py
@@ -124,7 +124,6 @@ _allrelacl_tpl = dict(
       FROM pg_catalog.pg_namespace nsp
       LEFT OUTER JOIN pg_catalog.pg_class AS rel
         ON rel.relnamespace = nsp.oid AND relkind = '%(t)s'
-      WHERE nspname NOT LIKE 'pg_%%'
       GROUP BY 1, 2
     ),
     all_grants AS (
@@ -191,7 +190,6 @@ _allprocacl_tpl = dict(
       FROM pg_catalog.pg_namespace nsp
       LEFT OUTER JOIN pg_catalog.pg_proc AS pro
         ON pro.pronamespace = nsp.oid
-      WHERE nspname NOT LIKE 'pg_%%'
       GROUP BY 1, 2
     ),
     roles AS (


### PR DESCRIPTION
New batch of improvement:

- Manage PUBLIC role for datacl, nspacl and proacl. If public is not explicitly granted, it is revoked :-)
- Provide `__temporary__` and `__create_on_schema__` well known ACL.
- Don't filter `pg_%` schema. Access to `pg_catalog` can be revoked.