### PR TITLE
Remove None from ldap defaults

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 
 # ldap2pg 4.4 (unreleased)
 
+- Fix uninitialized ldap parameters.
 - Fix `__all_on_schemas__` group including a `sequences` ACL.
 - Add `*_on_tables__` ACL for all privileges on table.
 

--- a/ldap2pg/ldap.py
+++ b/ldap2pg/ldap.py
@@ -218,10 +218,10 @@ class Options(dict):
 
 def gather_options(environ=None, **kw):
     options = Options(
-        URI=None,
+        URI='',
         HOST='',
         PORT=389,
-        BINDDN=None,
+        BINDDN='',
         USER=None,
         PASSWORD='',
     )


### PR DESCRIPTION
Fixes:

    Doing: ldapwhoami -x -D None
    Unhandled error:
    Traceback (most recent call last):
      File "/usr/local/lib/python2.7/dist-packages/ldap2pg/script.py", line 79, in main
        exit(wrapped_main(config))
      File "/usr/local/lib/python2.7/dist-packages/ldap2pg/script.py", line 30, in wrapped_main
        ldapconn = ldap.connect(**config['ldap'])
      File "/usr/local/lib/python2.7/dist-packages/ldap2pg/ldap.py", line 190, in connect
        l.simple_bind_s(options['BINDDN'], options['PASSWORD'])
      File "/usr/local/lib/python2.7/dist-packages/ldap2pg/ldap.py", line 145, in simple_bind_s
        return self.wrapped.simple_bind_s(binddn, password)
      File "/usr/local/lib/python2.7/dist-packages/ldap2pg/ldap.py", line 109, in __call__
        return decode_value(self.callable_(*a, **kw))
      File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 207, in simple_bind_s
        msgid = self.simple_bind(who,cred,serverctrls,clientctrls)
      File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 201, in simple_bind
        return self._ldap_call(self._l.simple_bind,who,cred,RequestControlTuples(serverctrls),RequestControlTuples(clientctrls))
      File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 99, in _ldap_call
        result = func(*args,**kwargs)
    TypeError: must be string, not None