### PR TITLE
Manager unknown parent

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 - Fix uninitialized ldap parameters.
 - Fix `__all_on_schemas__` group including a `sequences` ACL.
 - Fix user drop with Postgres 9.4.
+- Fix traceback on unknown parent.
 - Add `*_on_tables__` ACL for all privileges on table.
 - Allow to customize managed databases with `postgres:databases_query`.
 - Allow pure static configuration (aka ldap2pg without LDAP).

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -365,7 +365,10 @@ class SyncManager(object):
         logger.debug("Postgres inspection done.")
         ldaproles, ldapacls = self.inspect_ldap(syncmap)
         logger.debug("LDAP inspection completed. Post processing.")
-        ldaproles.resolve_membership()
+        try:
+            ldaproles.resolve_membership()
+        except ValueError as e:
+            raise UserError(str(e))
 
         count = 0
         count += self.run_queries(

--- a/ldap2pg/role.py
+++ b/ldap2pg/role.py
@@ -189,7 +189,10 @@ class RoleSet(set):
         for role in self:
             while role.parents:
                 parent_name = role.parents.pop()
-                parent = index_[parent_name]
+                try:
+                    parent = index_[parent_name]
+                except KeyError:
+                    raise ValueError('Unknown parent role %s' % parent_name)
                 if role.name in parent.members:
                     continue
                 logger.debug("Add %s as member of %s.", role.name, parent.name)

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -581,7 +581,7 @@ def test_sync(mocker):
     da = mocker.patch(cls + '.diff_acls', autospec=True)
     rq = mocker.patch(cls + '.run_queries', autospec=True)
 
-    from ldap2pg.manager import SyncManager
+    from ldap2pg.manager import SyncManager, UserError
 
     manager = SyncManager()
 
@@ -611,3 +611,7 @@ def test_sync(mocker):
     rq.return_value = 0
     count = manager.sync(syncmap=[])
     assert 0 == count
+
+    il.return_value[0].resolve_membership.side_effect = ValueError()
+    with pytest.raises(UserError):
+        manager.sync(syncmap=[])

--- a/tests/unit/test_role.py
+++ b/tests/unit/test_role.py
@@ -133,3 +133,8 @@ def test_resolve_membership():
 
     assert not oscar.parents
     assert 'oscar' in alice.members
+
+    alice.parents = ['unknown']
+
+    with pytest.raises(ValueError):
+        roles.resolve_membership()


### PR DESCRIPTION
Fixes:

    Unhandled error:
    Traceback (most recent call last):
      File ".../ldap2pg/ldap2pg/script.py", line 84, in main
        exit(wrapped_main(config))
      File ".../ldap2pg/ldap2pg/script.py", line 64, in wrapped_main
        count = manager.sync(syncmap=config['sync_map'])
      File ".../ldap2pg/ldap2pg/manager.py", line 368, in sync
        ldaproles.resolve_membership()
      File ".../ldap2pg/ldap2pg/role.py", line 192, in resolve_membership
        parent = index_[parent_name]
    KeyError: 'lecteurs'
    Please file an issue at https://github.com/dalibo/ldap2pg/issues with full log.