### PR TITLE
Catch unknown host on psql connect

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 - Fix `__all_on_schemas__` group including a `sequences` ACL.
 - Fix user drop with Postgres 9.4.
 - Fix traceback on unknown parent.
+- Fix traceback on unknown `PGHOST`.
 - Add `*_on_tables__` ACL for all privileges on table.
 - Allow to customize managed databases with `postgres:databases_query`.
 - Allow pure static configuration (aka ldap2pg without LDAP).

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -17,6 +17,7 @@ from os import stat
 import re
 import sys
 
+import psycopg2
 import yaml
 
 from . import __version__
@@ -80,11 +81,13 @@ class VersionAction(_VersionAction):
 
         version = (
             "%(package)s %(version)s\n"
+            "psycopg2 %(psycopg2version)s\n"
             "%(pyldap)s %(ldapversion)s\n"
             "Python %(pyversion)s\n"
         ) % dict(
             package=__package__,
             version=__version__,
+            psycopg2version=psycopg2.__version__,
             pyversion=sys.version,
             pyldap=pyldap.project_name,
             ldapversion=pyldap.version,

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -42,13 +42,13 @@ def wrapped_main(config=None):
         logger.warn("Running in real mode.")
 
     psql = PSQL(connstring=config['postgres']['dsn'])
-    with psql('postgres') as psql_:
-        try:
+    try:
+        with psql('postgres') as psql_:
             supported_columns = psql_(RoleOptions.COLUMNS_QUERY).fetchone()[0]
-        except psycopg2.OperationalError as e:
-            message = "Failed to connect to Postgres: %s." % (str(e).strip(),)
-            raise ConfigurationError(message)
-        RoleOptions.update_supported_columns(supported_columns)
+    except psycopg2.OperationalError as e:
+        message = "Failed to connect to Postgres: %s." % (str(e).strip(),)
+        raise ConfigurationError(message)
+    RoleOptions.update_supported_columns(supported_columns)
 
     manager = SyncManager(
         ldapconn=ldapconn, psql=psql,


### PR DESCRIPTION
Fixes:

    Unhandled error:
    Traceback (most recent call last):
      File ".../ldap2pg/ldap2pg/script.py", line 84, in main
        exit(wrapped_main(config))
      File ".../ldap2pg/ldap2pg/script.py", line 45, in wrapped_main
        with psql('postgres') as psql_:
      File ".../ldap2pg/ldap2pg/psql.py", line 77, in __enter__
        self.conn = psycopg2.connect(self.connstring)
      File ".../psycopg2/__init__.py", line 130, in connect
        conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
    psycopg2.OperationalError: could not translate host name "postgres.demo.docker" to address: Name or service not known