### PR TITLE
Reuse existing roles

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 - Fix `ALTER DEFAULT PRIVILEGES` on blacklisted roles.
 - Warn about undetermined `ALTER DEFAULT PRIVILEGES`.
 - Sort GRANT/REVOKE by role first.
+- Reuse existing role. Drop roles only from `managed_roles_query`.
 
 
 # ldap2pg 4.6

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -328,10 +328,9 @@ class Configuration(dict):
             # https://www.postgresql.org/docs/current/static/catalog-pg-auth-members.html
             'roles_query': dedent("""\
             SELECT
-                role.rolname, array_agg(members.rolname) AS members,
-                {options}
+              role.rolname, array_agg(members.rolname) AS members, {options}
             FROM
-                pg_catalog.pg_roles AS role
+              pg_catalog.pg_roles AS role
             LEFT JOIN pg_catalog.pg_auth_members ON roleid = role.oid
             LEFT JOIN pg_catalog.pg_roles AS members ON members.oid = member
             GROUP BY role.rolname, {options}
@@ -343,6 +342,7 @@ class Configuration(dict):
             WHERE role.rolsuper IS TRUE
             ORDER BY 1;
             """),
+            'managed_roles_query': None,
             'schemas_query': dedent("""\
             SELECT nspname FROM pg_catalog.pg_namespace
             ORDER BY 1;
@@ -373,6 +373,7 @@ class Configuration(dict):
         Mapping('postgres:databases_query', env=None),
         Mapping('postgres:owners_query', env=None),
         Mapping('postgres:roles_query', env=None),
+        Mapping('postgres:managed_roles_query', env=None),
         Mapping('postgres:schemas_query', env=None),
         Mapping('acls', env=None, processor=V.acls),
         Mapping('acl_dict', processor=V.acldict),

--- a/ldap2pg/role.py
+++ b/ldap2pg/role.py
@@ -227,3 +227,6 @@ class RoleSet(set):
         for name in sorted(index.keys()):
             for i in walk(name):
                 yield index[i]
+
+    def union(self, other):
+        return self.__class__(self | other)

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -58,6 +58,7 @@ def wrapped_main(config=None):
         databases_query=config['postgres']['databases_query'],
         owners_query=config['postgres']['owners_query'],
         roles_query=config['postgres']['roles_query'],
+        managed_roles_query=config['postgres']['managed_roles_query'],
         schemas_query=config['postgres']['schemas_query'],
         dry=config['dry'],
     )


### PR DESCRIPTION
When migrating to `ldap2pg` we often encounter failure on `CREATE ROLE` when a role already exists in database. This happen when `ldap2pg` is scoped but existing roles are not detected in the scoped `roles_query`. This PR try to solve this.

A new setting `managed_roles_query`. This query should be the first solution for narrowing scope of `ldap2pg`. This query returns the flat list of roles `ldap2pg` is allowed to drop or revoke (for heritage).

`ldap2pg` allways inspect *all* roles in database using `roles_query`, as usual. This query inspect membership and options.

When a role is required by LDAP, `ldap2pg` checks in `roles_query`, not in `managed_roles_query`. If a role exists in `roles_query` but not in `managed_roles_query` a warn is issued. If configured properly, an `ALTER` or a `GRANT` should make the `role` appear in `managed_roles_query` on next run.

I have a big update on sample `ldap2pg.yml` with a more real case. I'll review fixtures and func tests according.