### PR TITLE
Increase performances

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 - Warn about undetermined `ALTER DEFAULT PRIVILEGES`.
 - Sort GRANT/REVOKE by dbname and role first.
 - Reuse existing role. Drop roles only from `managed_roles_query`.
+- Commit transaction when changing database. This increase performances a lot.
 
 
 # ldap2pg 4.6

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 - Fix `__usage_on_types__` regranted for each owner.
 - Fix `ALTER DEFAULT PRIVILEGES` on blacklisted roles.
 - Warn about undetermined `ALTER DEFAULT PRIVILEGES`.
-- Sort GRANT/REVOKE by role first.
+- Sort GRANT/REVOKE by dbname and role first.
 - Reuse existing role. Drop roles only from `managed_roles_query`.
 
 

--- a/ldap2pg/acl.py
+++ b/ldap2pg/acl.py
@@ -170,7 +170,8 @@ class AclItem(object):
         return self.as_tuple() == other.as_tuple()
 
     def as_tuple(self):
-        return (self.role, self.acl, self.dbname, self.schema, self.owner)
+        return (
+            self.dbname or '', self.role, self.acl, self.schema, self.owner)
 
     def copy(self, **kw):
         return self.__class__(**dict(dict(

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -40,8 +40,7 @@ def wrapped_main(config=None):
         logger.warn("Running in dry mode. Postgres will be untouched.")
     else:
         logger.warn("Running in real mode.")
-
-    psql = PSQL(connstring=config['postgres']['dsn'])
+    psql = PSQL(connstring=config['postgres']['dsn'], dry=config['dry'])
     try:
         with psql() as psql_:
             supported_columns = psql_(RoleOptions.COLUMNS_QUERY).fetchone()[0]
@@ -60,7 +59,6 @@ def wrapped_main(config=None):
         roles_query=config['postgres']['roles_query'],
         managed_roles_query=config['postgres']['managed_roles_query'],
         schemas_query=config['postgres']['schemas_query'],
-        dry=config['dry'],
     )
     count = manager.sync(syncmap=config['sync_map'])
 


### PR DESCRIPTION
ALTER DEFAULT PRIVILEGES generates *lots* of requests : nb_databases * nb_schemas * nb_owners * * nb_acl * nb_grantee. Committing on each query cost a lot while there is not needed actually.

With this PR, queries are grouped by database and once `ldap2pg` has to work on another database, it commit its transaction. The gain is very important. With about 5000 queries, `ldap2pg` runs 7 times faster.