### PR TITLE
Fix traceback on unknown schema

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 # Unreleased
 
 - Check YAML gotchas.
+- Fix traceback on unknown schema.
 - pyldap has been merged in python-ldap. Dropping pyldap.
 
 

--- a/ldap2pg/acl.py
+++ b/ldap2pg/acl.py
@@ -123,7 +123,13 @@ class DefAcl(NspAcl):
 
     def expand(self, item, databases):
         for expand in super(DefAcl, self).expand(item, databases):
-            for owner in databases[expand.dbname][expand.schema]:
+            try:
+                owners = databases[expand.dbname][expand.schema]
+            except KeyError as e:
+                msg = "Unknown schema %s.%s." % (
+                    expand.dbname, expand.schema)
+                raise UserError(msg)
+            for owner in owners:
                 yield expand.copy(owner=owner)
 
 

--- a/tests/unit/test_acl.py
+++ b/tests/unit/test_acl.py
@@ -53,7 +53,7 @@ def test_revoke():
 
 
 def test_expand_defacl():
-    from ldap2pg.acl import DefAcl, AclSet, AclItem
+    from ldap2pg.acl import DefAcl, AclSet, AclItem, UserError
 
     acl = DefAcl('select', grant='ALTER FOR GRANT SELECT')
     item0 = AclItem(
@@ -86,6 +86,13 @@ def test_expand_defacl():
     assert 3 == len(items)
     assert 'postgres' == items[0].dbname
     assert 'template1' == items[2].dbname
+
+    with pytest.raises(UserError):
+        list(set_.expanditems(
+            aliases=dict(select=['select']),
+            acl_dict={acl.name: acl},
+            databases=dict(),
+        ))
 
 
 def test_expand_datacl():


### PR DESCRIPTION
Fixes:

    Traceback (most recent call last):
      File ".../ldap2pg/script.py", line 87, in main
        exit(wrapped_main(config))
      File ".../ldap2pg/script.py", line 67, in wrapped_main
        count = manager.sync(syncmap=config['sync_map'])
      File ".../ldap2pg/manager.py", line 259, in sync
        count += self.psql.run_queries(expandqueries(
      File ".../ldap2pg/manager.py", line 170, in postprocess_acls
        ldapacls.add(aclitem)
      File ".../ldap2pg/acl.py", line 201, in expanditems
        for expansion in acl.expand(item, databases):
      File ".../ldap2pg/acl.py", line 126, in expand
        for owner in databases[expand.dbname][expand.schema]:
    KeyError: 'inexistant'