### PR TITLE
Strip final new line in LDAP query filter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,11 @@ follow [merged Pull request
 pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
 
+# Unreleased
+
+- Fix Bad search filter when using multiline YAML string.
+
+
 # ldap2pg 4.11
 
 - Use PyYAML safe loading.

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -134,7 +134,11 @@ sync_map:
     - writers
 - ldap:
     base: ou=groups,dc=ldap,dc=ldap2pg,dc=docker
-    filter: "(cn=bi)"
+    filter: |
+      (&
+        (cn=bi)
+        (objectClass=*)
+      )
   role:
     name: '{member.cn}'
     options: LOGIN

--- a/ldap2pg/validators.py
+++ b/ldap2pg/validators.py
@@ -16,6 +16,8 @@ def ldapquery(value):
 
     query = dict(default_ldap_query, **value)
     query['scope'] = parse_scope(query['scope'])
+    if 'filter' in query:
+        query['filter'] = query['filter'].rstrip('\r\n')
 
     # Clean value from old manual attribute
     query.pop('attribute', None)


### PR DESCRIPTION
Fixes:

    [ldap2pg.script CRITI] Failed to query LDAP: {u'info': 'Resource temporarily unavailable', 'errno': 11, 'desc': u'Bad search filter'}.

Cf. #228 