### PR TITLE
Fix Active Directory search and mutiple search reference

### DIFF
--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -333,6 +333,7 @@ class Configuration(dict):
             'binddn': '',
             'user': None,
             'password': '',
+            'activedirectory': None,
         },
         'postgres': {
             'dsn': '',
@@ -386,6 +387,7 @@ class Configuration(dict):
         Mapping('ldap:binddn', env=['LDAPBINDDN', 'LDAP_BIND']),
         Mapping('ldap:user'),
         Mapping('ldap:password', secret=True),
+        Mapping('ldap:activedirectory'),
         Mapping(
             'postgres:dsn', env='PGDSN',
             secret=r'(?:password=|:[^/][^/].*@)',

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -333,7 +333,7 @@ class Configuration(dict):
             'binddn': '',
             'user': None,
             'password': '',
-            'activedirectory': None,
+            'referrals': True,
         },
         'postgres': {
             'dsn': '',
@@ -387,7 +387,7 @@ class Configuration(dict):
         Mapping('ldap:binddn', env=['LDAPBINDDN', 'LDAP_BIND']),
         Mapping('ldap:user'),
         Mapping('ldap:password', secret=True),
-        Mapping('ldap:activedirectory'),
+        Mapping('ldap:referrals', env=['REFERRALS']),
         Mapping(
             'postgres:dsn', env='PGDSN',
             secret=r'(?:password=|:[^/][^/].*@)',

--- a/ldap2pg/ldap.py
+++ b/ldap2pg/ldap.py
@@ -203,7 +203,7 @@ def connect(**kw):
 
     conn = LDAPLogger(conn)
 
-    if options.get('ACTIVEDIRECTORY'):
+    if not options.get('REFERRALS'):
         logger.debug("HOTFIX https://stackoverflow.com/questions/18793040/python-ldap-not-able-to-bind-successfully")
         conn.set_option(ldap.OPT_REFERRALS, 0)
 
@@ -253,7 +253,7 @@ def gather_options(environ=None, **kw):
         BINDDN='',
         USER=None,
         PASSWORD='',
-        ACTIVEDIRECTORY='',
+        REFERRALS='',
     )
 
     environ = environ or os.environ

--- a/ldap2pg/ldap.py
+++ b/ldap2pg/ldap.py
@@ -203,6 +203,10 @@ def connect(**kw):
 
     conn = LDAPLogger(conn)
 
+    if options.get('ACTIVEDIRECTORY'):
+        logger.debug("HOTFIX https://stackoverflow.com/questions/18793040/python-ldap-not-able-to-bind-successfully")
+        conn.set_option(ldap.OPT_REFERRALS, 0)
+
     if options.get('USER'):
         logger.debug("Trying SASL DIGEST-MD5 auth.")
         auth = sasl.sasl({
@@ -249,6 +253,7 @@ def gather_options(environ=None, **kw):
         BINDDN='',
         USER=None,
         PASSWORD='',
+        ACTIVEDIRECTORY='',
     )
 
     environ = environ or os.environ

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -48,6 +48,11 @@ class SyncManager(object):
             except UnicodeDecodeError as e:
                 message = "Failed to decode data from %r: %s." % (dn, e,)
                 raise UserError(message)
+
+            logger.debug("Evalutate entry: '%s' dn: '%s' attributes: '%s'", entry, dn, attributes)
+            if not dn:
+                continue
+
             entries.append(lower_attributes(entry))
         return entries
 
@@ -130,8 +135,7 @@ class SyncManager(object):
             if 'ldap' in mapping:
                 logger.info(
                     "Querying LDAP %.24s... %.12s...",
-                    mapping['ldap']['base'],
-                    mapping['ldap']['filter'].replace('\n', ''))
+                    mapping['ldap']['base'], mapping['ldap']['filter'])
                 entries = self.query_ldap(**mapping['ldap'])
                 log_source = 'in LDAP'
             else:

--- a/ldaprc
+++ b/ldaprc
@@ -2,3 +2,4 @@ BINDDN  cn=admin,dc=ldap,dc=ldap2pg,dc=docker
 BASE    dc=ldap,dc=ldap2pg,dc=docker
 TLS_REQCERT allow
 NETWORK_TIMEOUT 5
+REFERRALS on


### PR DESCRIPTION
Hi @bersace,
as asked on issue #228 here's the pull request.
In order to be simpler to manager Active Directory  I've added a new parameter in YML ldap section:
activedirectory: True/False

E.g. ldap2pg.yml
`ldap:`
`  uri: "ldap://pdc.office.company.com:389"`
`  binddn: CN=inetwork,OU=Network Service Account,DC=office,DC=company,DC=com`
`  user: OFFICE\inetwork`
`  password: "******"`
`  activedirectory: True`
