### PR TITLE
Allow to exclude public from privilege management

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,16 @@ follow [merged Pull request
 pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
 
+# Unreleased
+
+- Allow to exclude public from managed roles. When scoping ldap2pg to a subset
+  of roles, ldap2pg was including the public role, always. Now you can include
+  or exclude public by using `managed_roles_query` parameter. If you customized
+  `managed_roles_query` you **must update ldap2pg.yml** to include `public` to
+  keep the same behaviour. See [Synchronize a subset of
+  roles](postgres.md#synchronize-a-subset-of-roles) documentation section.
+
+
 # ldap2pg 4.13
 
 - Allow to configure behaviour on unexpected DN. Current behaviour are `ignore`,

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -37,6 +37,8 @@ synchronsize only a subset of roles, you need to customize inspection query in
 postgres:
   # Inspect only non SUPERUSER roles.
   managed_roles_query: |
+    SELECT 'public'
+    UNION
     SELECT rolname
     FROM pg_catalog.pg_roles
     WHERE rolsuper IS FALSE
@@ -51,6 +53,12 @@ A common case for this query is to return only members of a group like
 `ldap_roles`. This case is tested in
 [ldap2pg.yml](https://github.com/dalibo/ldap2pg/blob/master/ldap2pg.yml) sample.
 This way, `ldap2pg` is scoped to a subset of roles in the cluster.
+
+The `public` role does not exists in the system catalog. Thus if you want
+`ldap2pg` to manage `public` privileges, you must include explicitly `public` in
+the set of managed roles. This is the default. Of course, even if `public` is
+managed, `ldap2pg` won't drop or alter it if it's not in the directory.
+
 
 A safety net to completely ignore some roles is available : `blacklist`.
 `blacklist` is a list of `glob` patterns. Every roles matching one of

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -30,6 +30,8 @@ postgres:
     WHERE nspname = 'pg_catalog' OR nspname NOT LIKE 'pg_%'
   # Return managed roles which can be dropped or revoked.
   managed_roles_query: |
+    SELECT 'public'
+    UNION
     SELECT DISTINCT role.rolname
     FROM pg_roles AS role
     LEFT OUTER JOIN pg_auth_members AS ms ON ms.member = role.oid

--- a/ldap2pg/defaults.py
+++ b/ldap2pg/defaults.py
@@ -177,6 +177,11 @@ _allrelacl_tpl = dict(
       FROM pg_catalog.pg_class
       WHERE relkind IN %(t)s
       GROUP BY 1, 2, 3
+    ),
+    all_roles AS (
+      SELECT 0 AS oid, 'public' AS rolname
+      UNION
+      SELECT oid, rolname from pg_roles
     )
     SELECT
       nspname,
@@ -186,7 +191,7 @@ _allrelacl_tpl = dict(
         ELSE nsp.rels = COALESCE(grants.rels, ARRAY[]::name[])
       END AS "full"
     FROM namespace_rels AS nsp
-    CROSS JOIN pg_catalog.pg_roles AS rol
+    CROSS JOIN all_roles AS rol
     LEFT OUTER JOIN all_grants AS grants
       ON relnamespace = nsp.oid
          AND grantee = rol.oid

--- a/ldap2pg/role.py
+++ b/ldap2pg/role.py
@@ -287,7 +287,7 @@ class RoleSet(set):
                 yield qry
 
         # Don't forget to trash all spurious managed roles!
-        spurious = RoleSet(self - other)
+        spurious = RoleSet(self - other - set(['public']))
         for role in reversed(list(spurious.flatten())):
             for qry in role.drop():
                 yield qry

--- a/tests/unit/test_inspector.py
+++ b/tests/unit/test_inspector.py
@@ -53,18 +53,19 @@ def test_filter_roles():
         Role('alice'),
         Role('unmanaged'),
     ]
-    managedroles = {'alice', 'dba'}
+    managedroles = {'alice', 'dba', 'public'}
     allroles, managedroles = inspector.filter_roles(
         allroles, managedroles)
 
     assert 3 == len(allroles)
-    assert 2 == len(managedroles)
+    assert 3 == len(managedroles)
     assert 'dba' in allroles
     assert 'alice' in allroles
     assert 'unmanaged' in allroles
     assert 'unmanaged' not in managedroles
     assert 'postgres' not in allroles
     assert 'postgres' not in managedroles
+    assert 'public' in managedroles
 
 
 def test_process_grants():
@@ -178,7 +179,8 @@ def test_grants(mocker):
 
     grants = inspector.fetch_grants(
         schemas=dict(db=dict(public=['owner'])),
-        roles=['alice'])
+        roles=['alice', 'public'],
+    )
 
     assert 2 == len(grants)
     grantees = [a.role for a in grants]
@@ -214,7 +216,7 @@ def test_roles(mocker):
     assert 'postgres' in databases
     assert 'precreated' in pgallroles
     assert 'spurious' in pgallroles
-    assert pgallroles == pgmanagedroles
+    assert pgallroles < pgmanagedroles
 
     inspector.queries['managed_roles'] = ['precreated']
 

--- a/tests/unit/test_role.py
+++ b/tests/unit/test_role.py
@@ -173,6 +173,7 @@ def test_diff():
         Role('drop-me'),
         Role('alter-me'),
         Role('nothing'),
+        Role('public'),
     ])
     pgallroles = pgmanagedroles.union({
         Role('reuse-me'),
@@ -195,3 +196,4 @@ def test_diff():
     assert not fnfilter(queries, 'CREATE ROLE "reuse-me" *')
     assert not fnfilter(queries, '*nothing*')
     assert not fnfilter(queries, '*dont-touch-me*')
+    assert not fnfilter(queries, '*public*')


### PR DESCRIPTION
This can break advanced configuration with custom `managed_roles`. Keep reading the changelog ;-)

@cbandy, do you think the changelog and documentation update are enough ?