### PR TITLE
Ignore Amazon RDS users

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,11 @@ follow [merged Pull request
 pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
 
+# Unreleased
+
+- Add Amazon RDS admin roles in default blacklist.
+
+
 # ldap2pg 4.14
 
 - Allow to exclude public from managed roles. When scoping ldap2pg to a subset

--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -337,7 +337,7 @@ class Configuration(dict):
         },
         'postgres': {
             'dsn': '',
-            'blacklist': ['pg_*', 'postgres'],
+            'blacklist': ['pg_*', 'postgres', 'rds_*', 'rds*admin'],
             'databases_query': dedent("""\
             SELECT datname FROM pg_catalog.pg_database
             WHERE datallowconn IS TRUE ORDER BY 1;


### PR DESCRIPTION
That would be good to add other Cloud provides internal roles as well.