### PR TITLE
Fix schema naïve grant inspection with arbitrary schema

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 # Unreleased
 
 - Add Amazon RDS admin roles in default blacklist.
+- Fix schema naïve privilege inspection.
 
 
 # ldap2pg 4.14


### PR DESCRIPTION
This make the code match the documentation.

cf. #242 

@ankravch this should fix the weird behaviour with `SELECT 1, 'admin'`.