### PR TITLE
Fix newly created roles excluded from privileges inspection

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 
 - Add Amazon RDS admin roles in default blacklist.
 - Fix schema naïve privilege inspection.
+- Fix newly created roles excluded from privilege inspection.
 
 
 # ldap2pg 4.14

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -220,6 +220,8 @@ class SyncManager(object):
             databases=databases))
         if self.privileges:
             logger.info("Inspecting GRANTs in Postgres cluster...")
+            # Inject ldaproles in managed roles to avoid requerying roles.
+            pgmanagedroles.update(ldaproles)
             if self.psql.dry and count:
                 logger.warn(
                     "In dry mode, some owners aren't created, "


### PR DESCRIPTION
cf. #242 

This avoid having to rerun ldap2pg to synchronize privileges on new roles.