### PR TITLE
Fix warnings

### DIFF
--- a/ldap2pg/config.py
+++ b/ldap2pg/config.py
@@ -449,7 +449,7 @@ class Configuration(dict):
                 return os.path.realpath(candidate), stat_.st_mode
             except OSError as e:
                 if e.errno == errno.EACCES:
-                    logger.warn("Can't read %s: permission denied.", candidate)
+                    logger.warning("Can't read %s: permission denied.", candidate)
 
         if custom:
             message = "Can't access configuration file %s." % (custom,)
@@ -545,7 +545,7 @@ class Configuration(dict):
         logger.debug("Configuration loaded.")
 
         if not self['sync_map']:
-            logger.warn("Empty synchronization map!")
+            logger.warning("Empty synchronization map!")
 
     def merge(self, file_config, environ=os.environ, args=object()):
         for mapping in self.MAPPINGS:

--- a/ldap2pg/inspector.py
+++ b/ldap2pg/inspector.py
@@ -41,7 +41,7 @@ class PostgresInspector(object):
     def format_roles_query(self, name='all_roles'):
         query = self.queries[name]
         if not query:
-            logger.warn("Roles introspection disabled.")
+            logger.warning("Roles introspection disabled.")
             return
 
         if isinstance(query, list):
@@ -262,7 +262,7 @@ class PostgresInspector(object):
         pgacl = Acl()
         for name, privilege in sorted(self.privileges.items()):
             if not privilege.inspect:
-                logger.warn(
+                logger.warning(
                     "Can't inspect privilege %s: query not defined.",
                     privilege)
                 continue

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -104,7 +104,7 @@ class SyncManager(object):
                     if 'ignore' == on_unexpected_dn:
                         continue
                     elif 'warn' == on_unexpected_dn:
-                        logger.warn(msg)
+                        logger.warning(msg)
                     else:
                         raise UserError(msg)
                 except ValueError as e:
@@ -204,7 +204,7 @@ class SyncManager(object):
             self.inspector.roles_blacklist.append(me)
 
         if not issuper:
-            logger.warn("Running ldap2pg as non superuser.")
+            logger.warning("Running ldap2pg as non superuser.")
             RoleOptions.filter_super_columns()
 
         databases, pgallroles, pgmanagedroles = self.inspector.fetch_roles()
@@ -228,7 +228,7 @@ class SyncManager(object):
             # Inject ldaproles in managed roles to avoid requerying roles.
             pgmanagedroles.update(ldaproles)
             if self.psql.dry and count:
-                logger.warn(
+                logger.warning(
                     "In dry mode, some owners aren't created, "
                     "their default privileges can't be determined.")
             schemas = self.inspector.fetch_schemas(databases, ldaproles)

--- a/ldap2pg/privilege.py
+++ b/ldap2pg/privilege.py
@@ -246,7 +246,7 @@ class Acl(set):
         for priv, grants in groupby(spurious, lambda i: i.privilege):
             acl = privileges[priv]
             if not acl.revoke_sql:
-                logger.warn("Can't revoke %s: query not defined.", acl)
+                logger.warning("Can't revoke %s: query not defined.", acl)
                 continue
             for grant in grants:
                 yield acl.revoke(grant)
@@ -257,7 +257,7 @@ class Acl(set):
         for priv, grants in groupby(missing, lambda i: i.privilege):
             priv = privileges[priv]
             if not priv.grant_sql:
-                logger.warn("Can't grant %s: query not defined.", priv)
+                logger.warning("Can't grant %s: query not defined.", priv)
                 continue
             for grant in grants:
                 yield priv.grant(grant)

--- a/ldap2pg/role.py
+++ b/ldap2pg/role.py
@@ -293,7 +293,7 @@ class RoleSet(set):
             mine = my_roles_index[role.name]
             its = other_roles_index[role.name]
             if role not in self:
-                logger.warn(
+                logger.warning(
                     "Role %s already exists in cluster. Reusing.", role.name)
             for qry in mine.alter(its):
                 yield qry

--- a/ldap2pg/script.py
+++ b/ldap2pg/script.py
@@ -39,7 +39,7 @@ def wrapped_main(config=None):
         ldapconn = None
 
     if config.get('dry', True):
-        logger.warn("Running in dry mode. Postgres will be untouched.")
+        logger.warning("Running in dry mode. Postgres will be untouched.")
     else:
         logger.info("Running in real mode.")
     psql = PSQL(connstring=config['postgres']['dsn'], dry=config['dry'])

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -6,4 +6,5 @@ pytest
 pytest-cov
 pytest-mock
 pyyaml==3.10  # From CentOS7
+psycopg2-binary
 sh

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -403,7 +403,7 @@ def test_load_file(mocker):
     maplist = config['sync_map']
     assert 1 == len(maplist)
     assert 'DEBUG' == config['verbosity']
-    # logger.warn is called once for unknown_key, not for privileges.
+    # logger.warning is called once for unknown_key, not for privileges.
     assert 1 == warn.call_count
 
 

--- a/tests/unit/test_psql.py
+++ b/tests/unit/test_psql.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 
 
@@ -61,6 +63,7 @@ def test_psql(mocker):
 
     # Cleaning session triggers connexion closing.
     del psql, session
+    gc.collect()
 
     assert cursor.close.called is True
     assert conn.close.called is True


### PR DESCRIPTION
Fixes:

    …/ldap2pg/script.py:42: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
      logger.warn("Running in dry mode. Postgres will be untouched.")