### PR TITLE
Implement join between entries for AD queries

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ follow [merged Pull request
 pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
 
+# Unreleased
+
+- Allow joining LDAP entries based on DN attributes, e.g. to support role name
+  synchronization using the Active Directory (AD) attributes `sAMAccountName`
+  or `userPrincipalName`.
+
+
 # ldap2pg 4.18
 
 - Fix ref discarding.

--- a/docs/ldap.md
+++ b/docs/ldap.md
@@ -38,6 +38,14 @@ Relative Distinguished Name (RDN) of the value with a dot, like this:
 value `cn=toto,ou=people,dc=ldap,dc=acme,dc=fr`, `name: '{member.cn}''` will
 generate `toto`.
 
+You can also refer to attributes of LDAP entries referenced by the DN with the
+same syntax: `<attrname>.<attrname>`. An additional LDAP query will be
+performed to retrieve the requested attributes of the entry with the given DN.
+For exemple, if a LDAP entry has a `member` attribute with value
+`cn=toto,ou=people,dc=ldap,dc=acme,dc=fr` and the LDAP entry with that DN has
+a `userPrincipalName` attribute with value `toto@acme.fr`,
+`name: '{member.userPrincipalName}'` will generate `toto@acme.fr`.
+
 You can inject attributes in `role:names`, `role:parents`, `role:members` and
 `grant:role`.
 

--- a/fixtures/openldap-data.ldif
+++ b/fixtures/openldap-data.ldif
@@ -30,35 +30,55 @@ ou: people
 # Our database Administrators: a*
 dn: cn=ALICE,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: ALICE
+sn: Alice
+mail: alice@ldap2pg.docker
 
 dn: cn=Alan,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: Alan
+sn: Alan
+mail: alan@ldap2pg.docker
 
 dn: cn=albert,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: albert
+sn: Albert
+mail: albert@ldap2pg.docker
 
 # Alter has no luck, his name is a SQL literal ^^
 dn: cn=alter,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: alter
+sn: alter
+mail: alter@ldap2pg.docker
 
 # Our developers: d*
 dn: cn=daniel,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: daniel
+sn: Daniel
+mail: daniel@ldap2pg.docker
 
 dn: cn=david,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
@@ -68,30 +88,46 @@ cn: david
 
 dn: cn=denis,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: denis
+sn: Denis
+mail: denis@ldap2pg.docker
 
 dn: cn=didier,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: didier
+sn: Didier
+mail: didier@ldap2pg.docker
 
 # For unicode test
 dn:: Y249ZG9yb3Row6llLG91PXBlb3BsZSxkYz1sZGFwLGRjPWxkYXAycGcsZGM9ZG9ja2Vy
 changetype: add
-objectClass: organizationalRole
+objectclass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
 objectClass: uidObject
 objectClass: top
 cn:: ZG9yb3Row6ll
+sn:: ZG9yb3Row6ll
 uid: dorothee
+mail: dorothee@ldap2pg.docker
 
 dn: cn=domitille,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: domitille
+sn: Domitille
+mail: domitille@ldap2pg.docker
 
 # dimitri has no cn. For mixing DN.
 dn: uid=dimitri,ou=people,dc=ldap,dc=ldap2pg,dc=docker
@@ -100,32 +136,49 @@ objectClass: inetOrgPerson
 uid: dimitri
 sn: Dimitri
 cn: dimitri
+mail: dimitri@ldap2pg.docker
 
 # Our watchers: e*
 
 dn: cn=eve,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: eve
+sn: Eve
+mail: eve@ldap2pg.docker
 
 dn: cn=eloi,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: eloi
+sn: Eloi
+mail: eloi@ldap2pg.docker
 
 dn: cn=eloise,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: eloise
+sn: Eloise
+mail: eloise@ldap2pg.docker
 
 dn: cn=edouard,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 changetype: add
-objectclass: organizationalRole
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
 objectclass: top
 cn: edouard
+sn: Edouard
+mail: edouard@ldap2pg.docker
 
 # Our outsiders: o*
 

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -75,7 +75,7 @@ class SyncManager(object):
                         values_with_attrs.append((value, dict(sub_attrs)))
                         continue
 
-                    sub_attrs = { 'dn': [value] }
+                    sub_attrs = {'dn': [value]}
 
                     if not join['attributes']:
                         values_with_attrs.append((value, sub_attrs))
@@ -83,11 +83,14 @@ class SyncManager(object):
                         continue
 
                     join = dict(join, base=value)
-                    join_values = self._query_ldap(**join)
-                    if join_values:
-                        sub_attrs.update(join_values[0][1])
-                        values_with_attrs.append((value, sub_attrs))
-                        sub_attrs_cache[(attr, value)] = sub_attrs
+                    try:
+                        join_values = self._query_ldap(**join)
+                        if join_values:
+                            sub_attrs.update(join_values[0][1])
+                            values_with_attrs.append((value, sub_attrs))
+                            sub_attrs_cache[(attr, value)] = sub_attrs
+                    except UserError as e:
+                        logger.warn('Ignoring %s: %s' % (value, e))
 
                 entry[1][attr] = values_with_attrs
         return entries

--- a/ldap2pg/utils.py
+++ b/ldap2pg/utils.py
@@ -140,6 +140,13 @@ def iter_format_fields(strings, split=False):
             yield field
 
 
+def iter_format_sub_fields(strings):
+    for field in iter_format_fields(strings, split=False):
+        field, _, attr = field.partition('.')
+        if attr:
+           yield (field, attr)
+
+
 def list_descendant(groups, name):
     # Returns the recursive list of all descendant of name in hierarchy
     # `groups`. `groups` is a flat dict of `groups`

--- a/tests/func/ldap2pg.joins.yml
+++ b/tests/func/ldap2pg.joins.yml
@@ -1,0 +1,143 @@
+# This is the ldap2pg sample configuration adapted to use mail attribute
+# instead of CN to test the use of joins between LDAP entries.
+#
+
+verbosity: 5
+
+postgres:
+  # Scope the database where to purge objects when dropping roles. This is the
+  # scope of grant on `__all__` databases.
+  databases_query: [postgres, appdb, olddb]
+  # List of managed schema. This skip pg_toast, pg_temp1, etc. but not pg_catalog.
+  schemas_query: |
+    SELECT nspname FROM pg_catalog.pg_namespace
+    WHERE nspname = 'pg_catalog' OR nspname NOT LIKE 'pg_%'
+  # Return managed roles which can be dropped or revoked.
+  managed_roles_query: |
+    SELECT 'public'
+    UNION
+    SELECT DISTINCT role.rolname
+    FROM pg_roles AS role
+    LEFT OUTER JOIN pg_auth_members AS ms ON ms.member = role.oid
+    LEFT OUTER JOIN pg_roles AS ldap_roles
+      ON ldap_roles.rolname = 'ldap_roles' AND ldap_roles.oid = ms.roleid
+    WHERE role.rolname IN ('ldap_roles', 'readers', 'writers', 'owners')
+        OR ldap_roles.oid IS NOT NULL
+    ORDER BY 1;
+
+  # Since readers/writer/owners groups are globals, we have a global
+  # owners_query.
+  owners_query: |
+    SELECT DISTINCT role.rolname
+    FROM pg_catalog.pg_roles AS role
+    JOIN pg_catalog.pg_auth_members AS ms ON ms.member = role.oid
+    JOIN pg_catalog.pg_roles AS owners
+      ON owners.rolname = 'owners' AND owners.oid = ms.roleid
+    ORDER BY 1;
+
+
+privileges:
+  # Define an privilege group `ro` with read-only grants
+  ro:
+  - __connect__
+  - __execute__
+  - __select_on_tables__
+  - __select_on_sequences__
+  - __usage_on_schemas__
+  - __usage_on_types__
+
+  # `rw` privilege group lists write-only grants
+  rw:
+  - __temporary__
+  - __all_on_tables__
+  - __all_on_sequences__
+
+  # `ddl` privilege group lists DDL only grants.
+  ddl:
+  - __create_on_schemas__
+
+
+sync_map:
+# First, setup static roles and grants
+- roles:
+  - names:
+    - ldap_roles
+    - readers
+    options: NOLOGIN
+    comment: Custom static comment.
+  - name: writers
+    # Grant reading to writers
+    parent: readers
+    options: NOLOGIN
+  - name: owners
+    # Grant read/write to owners
+    parent: writers
+    options: NOLOGIN
+  # Now grant privileges to each groups
+  grant:
+  - privilege: ro
+    role: readers
+    # Let's everyone see pg_catalog
+    schema: __all__
+  - privilege: rw
+    role: writers
+    # But avoid writers to write in pg_catalog
+    schema: public
+  # Allow ddl to create tables in public only
+  - privilege: ddl
+    role: owners
+    schema: public
+  # owners must have write access to pg_catalog
+  - privilege: rw
+    role: owners
+    schema: pg_catalog
+  # Grants on specific schema appdb.appns:
+  - privilege: rw
+    role: writers
+    database: appdb
+    schema: appns
+  - privilege: ddl
+    role: owners
+    database: appdb
+    schema: appns
+
+# Now query LDAP to create roles and grant them privileges by parenting.
+- ldap:
+    base: ou=groups,dc=ldap,dc=ldap2pg,dc=docker
+    filter: "(cn=dba)"
+  role:
+    name: '{member.mail}'
+    options: LOGIN SUPERUSER
+    parent:
+    - ldap_roles
+    - owners
+    comment: "Custom comment from LDAP: {dn}"
+- ldap:
+    base: ou=groups,dc=ldap,dc=ldap2pg,dc=docker
+    filter: "(cn=app*)"
+    joins:
+      member:
+        filter: "(mail=*)"
+  role:
+    name: '{member.mail}'
+    options: LOGIN
+    parent:
+    - ldap_roles
+    - writers
+    on_unexpected_dn: warn
+- ldap:
+    base: ou=groups,dc=ldap,dc=ldap2pg,dc=docker
+    filter: |
+      (&
+        (cn=bi)
+        (objectClass=*)
+      )
+    joins:
+      member:
+        filter: "(mail=*)"
+  role:
+    name: '{member.mail}'
+    options: LOGIN
+    parent:
+    - ldap_roles
+    - readers

--- a/tests/func/test_sync.py
+++ b/tests/func/test_sync.py
@@ -67,6 +67,7 @@ def test_real_mode(dev, psql):
 
     assert 'daniel' in writers
     assert 'david' in writers
+    assert 'didier' in writers
     assert 'alice' in psql.members('ldap_roles')
 
     # Assert that table keepme owned by deleted user spurious is not dropped!
@@ -109,3 +110,25 @@ def test_re_revoke(dev, psql):
     # Synchronize all
     ldap2pg('-N', c=c)
     ldap2pg('-C', c=c)
+
+
+def test_joins_in_real_mode(dev, psql):
+    from sh import ldap2pg
+
+    ldap2pg('-N', c='tests/func/ldap2pg.joins.yml')
+    # Workaround bug in Postgres: execute on functions to public persists
+    # revoke.
+    ldap2pg('-N', c='tests/func/ldap2pg.joins.yml')
+
+    roles = list(psql.roles())
+    writers = list(psql.members('writers'))
+
+    assert 'alan@ldap2pg.docker' in roles
+    assert 'oscar@ldap2pg.docker' not in roles
+
+    assert 'alice@ldap2pg.docker' in psql.superusers()
+
+    assert 'daniel@ldap2pg.docker' in writers
+    assert 'david@ldap2pg.docker' not in writers
+    assert 'didier@ldap2pg.docker' in writers
+    assert 'alice@ldap2pg.docker' in psql.members('ldap_roles')

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -148,14 +148,19 @@ def test_expand_attributes():
     from ldap2pg.ldap import expand_attributes
 
     entry = ('dn', {
-        'cn': ['cn=pouet,ou=POU ET,dc=org'], 'uid': ['toto', 'titi']
+        'cn': [('cn=pouet,ou=POU ET,dc=org', {})],
+        'member': [('cn=pouet,ou=POU ET,dc=org', {'samaccountname': ['alice']})],
+        'uid': [('toto', {}), ('titi', {})]
     })
 
-    names = list(expand_attributes(entry, ['static', '{uid}', '{cn.dc}']))
+    names = list(expand_attributes(entry, [
+        'static', '{uid}', '{cn.dc}', '{member.samaccountname}',
+    ]))
     assert 'toto' in names
     assert 'static' in names
     assert 'titi' in names
     assert 'org' in names
+    assert 'alice' in names
 
 
 def test_get_attribute():
@@ -166,13 +171,19 @@ def test_get_attribute():
 
     with pytest.raises(RDNError):
         list(get_attribute(
-            entry=('dn', {'cn': ['cn=pouet']}),
-            attribute='cn.pouet',
+            entry=('dn', {'cn': [('cn=pouet', {})]}),
+            attribute='cn.ou',
         ))
 
     with pytest.raises(ValueError):
         list(get_attribute(
-            entry=('dn', {'cn': 'not a dn'}),
+            entry=('dn', {'cn': [('not a dn', {})]}),
+            attribute='cn.ou',
+        ))
+
+    with pytest.raises(ValueError):
+        list(get_attribute(
+            entry=('dn', {'cn': [('cn=pouet', {})]}),
             attribute='cn.pouet',
         ))
 

--- a/tests/unit/test_ldap.py
+++ b/tests/unit/test_ldap.py
@@ -149,7 +149,9 @@ def test_expand_attributes():
 
     entry = ('dn', {
         'cn': [('cn=pouet,ou=POU ET,dc=org', {})],
-        'member': [('cn=pouet,ou=POU ET,dc=org', {'samaccountname': ['alice']})],
+        'member': [
+            ('cn=pouet,ou=POU ET,dc=org', {'samaccountname': ['alice']})
+        ],
         'uid': [('toto', {}), ('titi', {})]
     })
 

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -16,7 +16,7 @@ def test_query_ldap(mocker):
 
     entries = manager.query_ldap(
         base='ou=people,dc=global', filter='(objectClass=*)',
-        scope=2, attributes=['cn'],
+        scope=2, joins={}, attributes=['cn'],
     )
 
     assert 2 == len(entries)
@@ -25,8 +25,91 @@ def test_query_ldap(mocker):
     with pytest.raises(UserError):
         manager.query_ldap(
             base='ou=people,dc=global', filter='(objectClass=*)',
-            scope=2, attributes=['cn'],
+            scope=2, joins={}, attributes=['cn'],
         )
+
+
+def test_query_ldap_joins(mocker):
+    from ldap2pg.manager import SyncManager
+
+    search_result = [
+        ('cn=A,ou=people,dc=global', {
+            'cn': ['A'], 'member': ['cn=P,ou=people,dc=global']}),
+        ('cn=B,ou=people,dc=global', {
+            'cn': ['B'], 'member': ['cn=P,ou=people,dc=global']}),
+    ]
+
+    sub_search_result = [
+        ('cn=P,ou=people,dc=global', {'sAMAccountName': ['P']}),
+    ]
+
+    manager = SyncManager(ldapconn=mocker.Mock())
+    manager.ldapconn.search_s.side_effect = [
+            search_result, sub_search_result]
+
+    entries = manager.query_ldap(
+        base='ou=people,dc=global', filter='(objectClass=group)',
+        scope=2, joins={'member': dict(
+            base='ou=people,dc=global',
+            scope=2,
+            filter='(objectClass=people)',
+            attributes=['sAMAccountName'],
+        )},
+        attributes=['cn', 'member'],
+    )
+
+    expected_entries = [
+        ('cn=A,ou=people,dc=global', {
+            'cn': [('A', {})],
+            'dn': [('cn=A,ou=people,dc=global', {})],
+            'member': [('cn=P,ou=people,dc=global', {
+                'dn': ['cn=P,ou=people,dc=global'],
+                'samaccountname': ['P'],
+            })],
+        }),
+        ('cn=B,ou=people,dc=global', {
+            'cn': [('B', {})],
+            'dn': [('cn=B,ou=people,dc=global', {})],
+            'member': [('cn=P,ou=people,dc=global', {
+                'dn': ['cn=P,ou=people,dc=global'],
+                'samaccountname': ['P'],
+            })],
+        }),
+    ]
+
+    assert expected_entries == entries
+
+    manager.ldapconn.search_s.side_effect = [search_result]
+
+    entries = manager.query_ldap(
+        base='ou=people,dc=global', filter='(objectClass=group)',
+        scope=2, joins={'member': dict(
+            base='ou=people,dc=global',
+            scope=2,
+            filter='(objectClass=people)',
+            attributes=[],
+        )},
+        attributes=['cn', 'member'],
+    )
+
+    expected_entries = [
+        ('cn=A,ou=people,dc=global', {
+            'cn': [('A', {})],
+            'dn': [('cn=A,ou=people,dc=global', {})],
+            'member': [('cn=P,ou=people,dc=global', {
+                'dn': ['cn=P,ou=people,dc=global'],
+            })],
+        }),
+        ('cn=B,ou=people,dc=global', {
+            'cn': [('B', {})],
+            'dn': [('cn=B,ou=people,dc=global', {})],
+            'member': [('cn=P,ou=people,dc=global', {
+                'dn': ['cn=P,ou=people,dc=global'],
+            })],
+        }),
+    ]
+
+    assert expected_entries == entries
 
 
 def test_query_ldap_bad_filter(mocker):
@@ -37,7 +120,8 @@ def test_query_ldap_bad_filter(mocker):
 
     with pytest.raises(UserError):
         manager.query_ldap(
-            base='dc=unit', filter='(broken', scope=2, attributes=[],
+            base='dc=unit', filter='(broken',
+            scope=2, joins={}, attributes=[],
         )
 
     assert manager.ldapconn.search_s.called is True
@@ -65,7 +149,7 @@ def test_process_entry_user():
 
     manager = SyncManager()
 
-    entry = ('dn', {'cn': ['alice', 'bob']})
+    entry = ('dn', {'cn': [('alice', {}), ('bob', {})]})
 
     roles = manager.process_ldap_entry(
         entry, names=['{cn}'],
@@ -84,7 +168,8 @@ def test_process_entry_dn():
 
     manager = SyncManager()
 
-    entry = ('dn', {'member': ['cn=alice,dc=unit', 'cn=bob,dc=unit']})
+    entry = ('dn', {
+        'member': [('cn=alice,dc=unit', {}), ('cn=bob,dc=unit', {})]})
 
     roles = manager.process_ldap_entry(entry, names=['{member.cn}'])
     roles = list(roles)
@@ -102,11 +187,11 @@ def test_process_entry_membership(mocker):
 
     entries = [
         ('cn=group0', {
-            'cn': ['group0'],
-            'member': ['cn=alice,dc=unit', 'cn=alain,dc=unit']}),
+            'cn': [('group0', {})],
+            'member': [('cn=alice,dc=unit', {}), ('cn=alain,dc=unit', {})]}),
         ('cn=group1', {
-            'cn': ['group1'],
-            'member': ['cn=bob,dc=unit', 'cn=benoit,dc=unit']}),
+            'cn': [('group1', {})],
+            'member': [('cn=bob,dc=unit', {}), ('cn=benoit,dc=unit', {})]}),
     ]
 
     roles = []

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -91,6 +91,16 @@ def test_iter_format_field():
     assert 'dot' in fields
 
 
+def test_iter_format_sub_field():
+    from ldap2pg.utils import iter_format_sub_fields
+
+    fields = list(iter_format_sub_fields(
+        ['static', '{simple}', '{dot.ted}'],
+    ))
+
+    assert ('dot', 'ted') in fields
+
+
 def test_settable():
     from ldap2pg.utils import Settable
 

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -160,6 +160,32 @@ def test_process_ldapquery():
     with pytest.raises(ValueError):
         mapping(dict(role='static', ldap=dict(base='dc=lol')))
 
+    v = mapping(dict(
+        role=dict(
+            name='{sAMAccountName}',
+            members='{member.sAMAccountName}',
+            comment='{member.cn}'),
+        ldap=dict(base='o=acme', join=dict(member=dict(
+            filter='(objectClass=person)'))))
+    )
+
+    assert 'member' in v['ldap']['attributes']
+    assert 'sAMAccountName' in v['ldap']['attributes']
+    assert '(objectClass=person)' == v['ldap']['joins']['member']['filter']
+    assert ['sAMAccountName'] == v['ldap']['joins']['member']['attributes']
+
+    v = mapping(dict(
+        role=dict(
+            name='{sAMAccountName}',
+            members='{member.sAMAccountName}'),
+        ldap=dict(base='o=acme'))
+    )
+
+    assert 'member' in v['ldap']['attributes']
+    assert 'sAMAccountName' in v['ldap']['attributes']
+    assert 'filter' in v['ldap']['joins']['member']
+    assert ['sAMAccountName'] == v['ldap']['joins']['member']['attributes']
+
 
 def test_process_rolerule():
     from ldap2pg.validators import rolerule


### PR DESCRIPTION
Allow joining LDAP entries together based on a DN attribute. The syntax is similar to the one used to give the CN of a DN attribute (e.g. `{member.cn}`) and allow to give entry attributes through an additional LDAP query (e.g. `{member.userPrincipalName}`).

The `ldap` configuration has been extended with one additional attribute `joins` to permit the user to specify the filter to be used for the query (e.g. to filter out entries not having the referenced attribute).

Thanks in advance for the review.