### PR TITLE
Manage GSSAPI SASL mech

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
   synchronization using the Active Directory (AD) attributes `sAMAccountName`
   or `userPrincipalName`.
 - Fix default ldap settings overriding ldaprc values.
+- Support GSSAPI authentification for Kerberos. Thanks @djkube for testing.
 
 
 # ldap2pg 4.18

--- a/ldap2pg/utils.py
+++ b/ldap2pg/utils.py
@@ -144,7 +144,7 @@ def iter_format_sub_fields(strings):
     for field in iter_format_fields(strings, split=False):
         field, _, attr = field.partition('.')
         if attr:
-           yield (field, attr)
+            yield (field, attr)
 
 
 def list_descendant(groups, name):


### PR DESCRIPTION
Cf. #268 

@djkube The SASL API is not a generic abstaction over various method. It's just a somewhat consistent gateway to various SASL module API. Thus, I have to implement each SASL mechanism sperately. This PR adds GSSAPI.

Can you test it ?

Regards,