### PR TITLE
Feature/dockerfile best practice

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,6 @@ RUN set -ex; \
         python3-setuptools=40.8.0-1 \
         python3-yaml=3.13-2 \
     ; \
-    apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
     :
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,19 +3,19 @@ FROM debian:buster-slim
 RUN set -ex; \
     apt-get update -y; \
     apt-get install -y --no-install-recommends \
-        python3 \
-        python3-ldap \
-        python3-pip \
-        python3-psycopg2 \
-        python3-setuptools \
-        python3-yaml \
+        python3=3.7.2-1 \
+        python3-ldap=3.1.0-2 \
+        python3-pip=18.1-5 \
+        python3-psycopg2=2.7.7-1 \
+        python3-setuptools=40.8.0-1 \
+        python3-yaml=3.13-2 \
     ; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
     :
 
 RUN set -ex; \
-    pip3 --no-cache-dir install --no-deps ldap2pg; \
+    pip3 --no-cache-dir install --no-deps ldap2pg==4.18; \
     ldap2pg --version; \
     :
 


### PR DESCRIPTION
# Description

I have made a couple of changes to the repositories Dockerfile, so that it follows the standard-best-practice recommendations.

- Pin package versions
- No need to run apt-clean in official debian image

----
[Dockerfile lint](https://github.com/hadolint/hadolint/wiki/DL3008)
> Version pinning forces the build to retrieve a particular version regardless of what’s in the cache. This technique can also reduce failures due to unanticipated changes in required packages.

[Dockerfile best practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
> Official Debian and Ubuntu images automatically run apt-get clean, so explicit invocation is not required.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Image can build through make
- [X] ldap2pg still works as expected

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings