### PR TITLE
Respect case of role name

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,11 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 
 # Unreleased
 
+**Beware** when upgrading : **ldap2pg will drop roles having uppercase letter in
+their name!** These roles will be recreated with case respected.
+
+- ldap2pg now respect case for role names. Thanks to [Sergejs
+  Zuromskis](@zurikus) for the report.
 - Postgres 12 support validated.
 - Fix void attributes raising *Missing attribute error*.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,8 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 # Unreleased
 
 **Beware** when upgrading : **ldap2pg will drop roles having uppercase letter in
-their name!** These roles will be recreated with case respected.
+their name!** These roles will be recreated with case respected. Run with
+`--dry` before and check for warnings about detected name changes.
 
 - ldap2pg now respect case for role names. Thanks to [Sergejs
   Zuromskis](@zurikus) for the report.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,9 +9,9 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 
 # Unreleased
 
-**Beware** when upgrading : **ldap2pg will drop roles having uppercase letter in
-their name!** These roles will be recreated with case respected. Run with
-`--dry` before and check for warnings about detected name changes.
+**Beware** when upgrading : **ldap2pg will rename roles having uppercase letter
+in their name!** These roles will be renamed from lowercase to original case.
+Run `ldap2pg --dry` before and check for renames.
 
 - ldap2pg now respect case for role names. Thanks to [Sergejs
   Zuromskis](@zurikus) for the report.

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -94,14 +94,8 @@ class SyncManager(object):
         return entries
 
     def process_ldap_entry(self, entry, names, **kw):
-        members = [
-            m.lower() for m in
-            expand_attributes(entry, kw.get('members', []))
-        ]
-        parents = [
-            p.lower() for p in
-            expand_attributes(entry, kw.get('parents', []))
-        ]
+        members = list(expand_attributes(entry, kw.get('members', [])))
+        parents = list(expand_attributes(entry, kw.get('parents', [])))
         comment = kw.get('comment', None)
         if comment:
             try:
@@ -114,7 +108,6 @@ class SyncManager(object):
 
         for name in expand_attributes(entry, names):
             log_source = " from " + ("YAML" if name in names else entry[0])
-            name = name.lower()
 
             logger.debug("Found role %s%s.", name, log_source)
             if members:

--- a/ldap2pg/role.py
+++ b/ldap2pg/role.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 class Role(object):
     __slots__ = (
         'comment',
+        'lname',
         'members',
         'name',
         'options',
@@ -22,6 +23,7 @@ class Role(object):
     def __init__(self, name, options=None, members=None, parents=None,
                  comment=None):
         self.name = name
+        self.lname = name.lower()
         self.members = members or []
         self.options = RoleOptions(options or {})
         self.parents = parents or []
@@ -282,6 +284,11 @@ class RoleSet(set):
         # First create missing roles
         missing = RoleSet(other - available)
         for role in missing.flatten():
+            if role.lname in self and role.lname not in other:
+                logger.warning(
+                    "%s role will be dropped and %s created. "
+                    "You may need to reassign objets.",
+                    role.lname, role.name)
             for qry in role.create():
                 yield qry
 

--- a/tests/func/test_sync.py
+++ b/tests/func/test_sync.py
@@ -38,7 +38,7 @@ def test_dry_run(dev, psql):
     superusers = list(psql.superusers())
     # oscar is not dropped
     assert 'oscar' in roles
-    assert 'alice' in superusers
+    assert 'ALICE' in superusers
 
 
 def test_check_mode(dev, psql):
@@ -60,15 +60,15 @@ def test_real_mode(dev, psql):
     roles = list(psql.roles())
     writers = list(psql.members('writers'))
 
-    assert 'alan' in roles
+    assert 'Alan' in roles
     assert 'oscar' not in roles
 
-    assert 'alice' in psql.superusers()
+    assert 'ALICE' in psql.superusers()
 
     assert 'daniel' in writers
     assert 'david' in writers
     assert 'didier' in writers
-    assert 'alice' in psql.members('ldap_roles')
+    assert 'ALICE' in psql.members('ldap_roles')
 
     # Assert that table keepme owned by deleted user spurious is not dropped!
     assert 'keepme' in psql.tables(dbname='olddb')

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -156,7 +156,7 @@ def test_process_entry_static():
     roles = list(roles)
 
     assert 1 == len(roles)
-    assert 'alice' in roles
+    assert 'ALICE' in roles
     assert 'postgres' in roles[0].parents
     assert 'Custom.' == roles[0].comment
 

--- a/tests/unit/test_role.py
+++ b/tests/unit/test_role.py
@@ -72,6 +72,16 @@ def test_merge():
     assert 1 == len(a.members)
 
 
+def test_rename():
+    from ldap2pg.role import Role
+
+    a = Role(name='Alan')
+    queries = [q.args[0] for q in a.rename()]
+    alter = queries[0]
+
+    assert 'RENAME TO' in alter
+
+
 def test_merge_options():
     from ldap2pg.role import Role
 
@@ -172,9 +182,10 @@ def test_diff():
 
     pgmanagedroles = RoleSet([
         Role('drop-me'),
-        Role('alter-me'),
+        Role('alter-me', members=['rename-me']),
         Role('nothing'),
         Role('public'),
+        Role('rename-me'),
     ])
     pgallroles = pgmanagedroles.union({
         Role('reuse-me'),
@@ -182,9 +193,10 @@ def test_diff():
     })
     ldaproles = RoleSet([
         Role('reuse-me'),
-        Role('alter-me', options=dict(LOGIN=True)),
+        Role('alter-me', options=dict(LOGIN=True), members=['Rename-Me']),
         Role('nothing'),
-        Role('create-me')
+        Role('create-me'),
+        Role('Rename-Me'),
     ])
     queries = [
         q.args[0]


### PR DESCRIPTION
cf. #289 

This **may** break installation relying on ldap2pg lowering case when creating roles.