### PR TITLE
No need to run apt-clean on offical debian image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN set -ex; \
         python3-setuptools \
         python3-yaml \
     ; \
-    apt-get clean; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
     :
 


### PR DESCRIPTION
@lokenorlinjohannessen I cherry-pick your commit for apt-clean.