### PR TITLE
Fix hash of grant

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,11 @@ follow [merged Pull request
 pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
 
+# Unreleased
+
+- Fix traceback when inspecting grants.
+
+
 # ldap2pg 5.1
 
 **Beware** when upgrading : **ldap2pg will rename roles having uppercase letter

--- a/ldap2pg/privilege.py
+++ b/ldap2pg/privilege.py
@@ -1,4 +1,3 @@
-from itertools import chain
 from itertools import groupby
 import logging
 
@@ -194,7 +193,7 @@ class Grant(object):
         return '<%s %s>' % (self.__class__.__name__, self)
 
     def __hash__(self):
-        return hash(''.join(chain(*filter(None, self.as_tuple()))))
+        return hash(tuple([unicode(x) for x in self.as_tuple()]))
 
     def __eq__(self, other):
         return self.as_tuple() == other.as_tuple()

--- a/ldap2pg/utils.py
+++ b/ldap2pg/utils.py
@@ -32,9 +32,6 @@ class AllDatabases(object):
     def __repr__(self):
         return '__ALL_DATABASES__'
 
-    def __iter__(self):
-        return iter([repr(self)])
-
 
 def dedent(s):
     return textwrap.dedent(s).strip()

--- a/tests/func/conftest.py
+++ b/tests/func/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from functools import partial
@@ -123,6 +124,8 @@ def lazy_write(attr, data):
 
 @pytest.fixture(scope='session', autouse=True)
 def sh_errout():
+    logging.getLogger('sh').setLevel(logging.ERROR)
+
     # Duplicate tested command stdio to pytest capsys.
     sh._SelfWrapper__self_module.Command._call_args.update(dict(
         err=partial(lazy_write, 'stderr'),

--- a/tests/unit/test_privileges.py
+++ b/tests/unit/test_privileges.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 from fnmatch import filter as fnfilter
@@ -17,6 +19,7 @@ def test_privilege_object():
 
 def test_grant_object():
     from ldap2pg.privilege import Privilege, Grant
+    from ldap2pg.role import Role
 
     priv = Privilege(name='connect', grant='GRANT {database} TO {role};')
     item = Grant(priv.name, dbname='backend', schema=None, role='daniel')
@@ -26,6 +29,11 @@ def test_grant_object():
     assert 'daniel' in qry.args[0]
 
     assert 'db' in repr(Grant('p', ['db'], ['schema']))
+
+    # Test hash with Role object.
+    str_h = hash(Grant('priv', ['db'], ['schema'], role=Role(u'rôle')))
+    obj_h = hash(Grant('priv', ['db'], ['schema'], role=u'rôle'))
+    assert str_h == obj_h
 
 
 def test_grant_set():


### PR DESCRIPTION
cc @bsislow

Fixes:

    Inspecting GRANTs in Postgres cluster...
    Unhandled error:
    Traceback (most recent call last):
    File "/usr/lib/python2.7/site-packages/ldap2pg/script.py", line 94, in main
        exit(wrapped_main(config))
    File "/usr/lib/python2.7/site-packages/ldap2pg/script.py", line 70, in wrapped_main
        count = manager.sync(syncmap=config['sync_map'])
    File "/usr/lib/python2.7/site-packages/ldap2pg/manager.py", line 267, in sync
        ldapacl = self.postprocess_acl(ldapacl, schemas)
    File "/usr/lib/python2.7/site-packages/ldap2pg/manager.py", line 225, in postprocess_acl
        acl.add(grant)
    File "/usr/lib/python2.7/site-packages/ldap2pg/privilege.py", line 197, in __hash__
        return hash(''.join(chain(*filter(None, self.as_tuple()))))
    TypeError: 'Role' object is not iterable