### PR TITLE
Refuse mispelled attributes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 # Unreleased
 
 - Fail when attribute is mispelled.
+- Fail when sub-querying on bad DN.
 - CentOS 8 support.
 - PostgreSQL 13 support.
 - Fix join order.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 
 # Unreleased
 
+- Fail when attribute is mispelled.
 - CentOS 8 support.
 - PostgreSQL 13 support.
 - Fix join order.

--- a/fixtures/openldap-data.ldif
+++ b/fixtures/openldap-data.ldif
@@ -257,7 +257,6 @@ objectClass: groupOfNames
 objectClass: top
 cn: team0
 # Missing description: comment will fallback to default.
-member: cn=carole,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 member: cn=daniel,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 member: cn=david,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 member: cn=didier,ou=people,dc=ldap,dc=ldap2pg,dc=docker
@@ -269,7 +268,6 @@ objectClass: groupOfNames
 objectClass: top
 cn: team1
 description: Desc of team1, should end in a comment.
-member: cn=carole,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 member: cn=daniel,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 member: cn=denis,ou=people,dc=ldap,dc=ldap2pg,dc=docker
 member: uid=dimitri,ou=people,dc=ldap,dc=ldap2pg,dc=docker

--- a/ldap2pg/ldap.py
+++ b/ldap2pg/ldap.py
@@ -113,8 +113,9 @@ def get_attribute(entry, attribute):
             msg = "Missing join result for %s." % (attribute,)
             raise ValueError(msg)
 
+        path = '.'.join(path)
         for joined_entry in joined_entries:
-            for value in get_attribute(joined_entry, '.'.join(path)):
+            for value in get_attribute(joined_entry, path):
                 yield value
 
 

--- a/ldap2pg/ldap.py
+++ b/ldap2pg/ldap.py
@@ -83,7 +83,7 @@ def get_attribute(entry, attribute):
     try:
         values = attributes[path[0]]
     except KeyError:
-        raise ValueError("Unknown attribute %r" % (path[0],))
+        raise ValueError("Unknown attribute %r." % (path[0],))
 
     attribute = path[0]
     path = path[1:]
@@ -96,7 +96,7 @@ def get_attribute(entry, attribute):
             try:
                 dn = str2dn(value)
             except ValueError:
-                msg = "Can't parse DN from attribute %s=%s" % (
+                msg = "Can't parse DN from attribute %s=%s." % (
                     attribute, value)
                 raise ValueError(msg)
             value = dict()
@@ -105,12 +105,12 @@ def get_attribute(entry, attribute):
             try:
                 yield value[path[0]]
             except KeyError:
-                yield RDNError("Unknown RDN %s" % (path[0],), raw_dn)
+                yield RDNError("Unknown RDN %s." % (path[0],), raw_dn)
     else:
         try:
             joined_entries = joins[attribute]
         except KeyError:
-            msg = "Missing join result for %s" % (attribute,)
+            msg = "Missing join result for %s." % (attribute,)
             raise ValueError(msg)
 
         for joined_entry in joined_entries:

--- a/ldap2pg/ldap.py
+++ b/ldap2pg/ldap.py
@@ -83,7 +83,7 @@ def get_attribute(entry, attribute):
     try:
         values = attributes[path[0]]
     except KeyError:
-        raise ValueError("Unknown attribute %r." % (path[0],))
+        raise ValueError("Missing attribute %s." % (path[0],))
 
     attribute = path[0]
     path = path[1:]

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -85,14 +85,9 @@ class SyncManager(object):
                     join_entries = join_cache.get(join_key)
                     if join_entries is None:
                         join_query = dict(join, base=value)
-                        try:
-                            logger.info("Sub-querying LDAP %.24s...", value)
-                            join_entries = self._query_ldap(**join_query)
-                            join_cache[join_key] = join_entries
-                        except UserError as e:
-                            logger.warning('Ignoring %s: %s', value, e)
-                            join_cache[join_key] = False
-                            continue
+                        logger.info("Sub-querying LDAP %.24s...", value)
+                        join_entries = self._query_ldap(**join_query)
+                        join_cache[join_key] = join_entries
                     if join_entries:
                         join_entries = entry_joins.get(attr, []) + join_entries
                         entry_joins[attr] = join_entries

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -74,6 +74,11 @@ class SyncManager(object):
         join_cache = {}
         for attr, join in joins.items():
             for dn, attrs, entry_joins in entries:
+                if attr not in attrs:
+                    raise UserError(
+                        "Missing attribute %s from %s. Can't subquery." %
+                        (attr, dn)
+                    )
                 for value in attrs[attr]:
                     # That would be nice to group all joins of one entry.
                     join_key = '%s/%s' % (attr, value)

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -48,15 +48,12 @@ class SyncManager(object):
 
         logger.debug('Got %d entries from LDAP.', len(raw_entries))
         entries = []
-        wanted_attribute_names = attributes
         for dn, attributes in raw_entries:
             if not dn:
                 logger.debug("Discarding ref: %.40s.", attributes)
                 continue
 
             attributes['dn'] = [dn]
-            for n in wanted_attribute_names:
-                attributes.setdefault(n, [])
 
             try:
                 entry = decode_value((dn, attributes))

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -154,7 +154,11 @@ class SyncManager(object):
         values = {}
         for field in fields:
             values.setdefault(field, [])
-            for value in get_attribute(entry, field):
+            try:
+                raw_values = list(get_attribute(entry, field))
+            except ValueError as e:
+                raise UserError(str(e))
+            for value in raw_values:
                 if isinstance(value, RDNError):
                     msg = "Unexpected DN: %s" % value.dn
                     if 'ignore' == on_unexpected_dn:

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -146,6 +146,7 @@ def test_inspect_ldap_unexpected_dn(mocker):
     ql.return_value = [('dn0', {}, {})]
 
     list(manager.inspect_ldap([dict(
+        description="Test query desc",
         ldap=dict(on_unexpected_dn='warn'),
         roles=[RoleRule(names=['{member.cn}'])],
     )]))

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -181,6 +181,26 @@ def test_inspect_ldap_unexpected_dn(mocker):
         )]))
 
 
+def test_inspect_ldap_missing_attribute(mocker):
+    ql = mocker.patch('ldap2pg.manager.SyncManager.query_ldap')
+
+    from ldap2pg.manager import SyncManager, UserError
+    from ldap2pg.role import RoleRule
+
+    manager = SyncManager()
+
+    # Don't return member attribute.
+    ql.return_value = [('dn0', {}, {})]
+
+    with pytest.raises(UserError) as ei:
+        list(manager.inspect_ldap([dict(
+            ldap=dict(base='...'),
+            # Request member attribute.
+            roles=[RoleRule(names=['{member.cn}'])],
+        )]))
+    assert 'Missing attribute member' in str(ei.value)
+
+
 def test_inspect_ldap_grants(mocker):
     from ldap2pg.manager import SyncManager
     from ldap2pg.privilege import Grant, NspAcl


### PR DESCRIPTION
@hlecleme je retire l'avertissement en cas de référence pourrie dans l'annuaire. Je préfère péter une erreur et éventuellement ajouter un comportement comme `on_unexpected_dn`.