### PR TITLE
Permit joins with all references filtered out

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 
 # Unreleased
 
+- Permit joins where all the referenced objects are filtered out. The join
+  name must be added to the list of attributes that may be missing in the
+  result.
 - Fail when attribute is misspelled. You must explicitly list attributes that
   may be missing in the result. By default, ldap2pg accepts missing `member`
   and considers it an empty list rather than a misspelled attribute.

--- a/ldap2pg/manager.py
+++ b/ldap2pg/manager.py
@@ -104,7 +104,7 @@ class SyncManager(object):
                         logger.info("Sub-querying LDAP %.24s...", value)
                         join_entries = self._query_ldap(**join_query)
                         join_cache[join_key] = join_entries
-                    if join_entries:
+                    if join_entries or attr in allow_missing_attributes:
                         join_entries = entry_joins.get(attr, []) + join_entries
                         entry_joins[attr] = join_entries
 


### PR DESCRIPTION
When a filter is present in the join operation, it could happen that all joined references are filtered out (although the reference attribute is present in the queried object). This will generate critical errors like `Missing join result for member`.

This change will make it possible to process objects where all references are filtered out whe the attribute is added to `allow_missing_attributes`.

Example to show the behavior:

```
- ldap:
    base: cn=team0,ou=groups,dc=ldap,dc=ldap2pg,dc=docker
    allow_missing_attributes: []
    joins:
      member:
        scope: base
        filter: (objectClass=groupOfNames)
  role:
    name: '{member.mail}'
    options: NOLOGIN
    parent:
    - '{cn}'
```

Result:

```
[ldap2pg.manager       INFO] Querying LDAP cn=team0,ou=groups,dc=ld... (objectClass...
[ldap2pg.ldap         DEBUG] Doing: ldapsearch -x -D cn=admin,dc=ldap,dc=ldap2pg,dc=docker -W -b cn=team0,ou=groups,dc=ldap,dc=ldap2pg,dc=docker -s sub '(objectClass=*)' member cn
[ldap2pg.manager      DEBUG] Got 1 entries from LDAP.
[ldap2pg.manager       INFO] Sub-querying LDAP cn=daniel,ou=people,dc=l...
[ldap2pg.ldap         DEBUG] Doing: ldapsearch -x -D cn=admin,dc=ldap,dc=ldap2pg,dc=docker -W -b cn=daniel,ou=people,dc=ldap,dc=ldap2pg,dc=docker -s base '(objectClass=groupOfNames)' mail
[ldap2pg.manager      DEBUG] Got 0 entries from LDAP.
[ldap2pg.manager       INFO] Sub-querying LDAP cn=david,ou=people,dc=ld...
[ldap2pg.ldap         DEBUG] Doing: ldapsearch -x -D cn=admin,dc=ldap,dc=ldap2pg,dc=docker -W -b cn=david,ou=people,dc=ldap,dc=ldap2pg,dc=docker -s base '(objectClass=groupOfNames)' mail
[ldap2pg.manager      DEBUG] Got 0 entries from LDAP.
[ldap2pg.manager       INFO] Sub-querying LDAP cn=didier,ou=people,dc=l...
[ldap2pg.ldap         DEBUG] Doing: ldapsearch -x -D cn=admin,dc=ldap,dc=ldap2pg,dc=docker -W -b cn=didier,ou=people,dc=ldap,dc=ldap2pg,dc=docker -s base '(objectClass=groupOfNames)' mail
[ldap2pg.manager      DEBUG] Got 0 entries from LDAP.
[ldap2pg.manager       INFO] Sub-querying LDAP cn=dorothée,ou=people,dc...
[ldap2pg.ldap         DEBUG] Doing: ldapsearch -x -D cn=admin,dc=ldap,dc=ldap2pg,dc=docker -W -b cn=dorothée,ou=people,dc=ldap,dc=ldap2pg,dc=docker -s base '(objectClass=groupOfNames)' mail
[ldap2pg.manager      DEBUG] Got 0 entries from LDAP.
[ldap2pg.script       CRITI] Missing join result for member.
```