### PR TITLE
Fix default value for allow_missing_attributes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 - Protect role name when reassigning objects.
 - Apply `LDAPCONF` `LDAPRC` from environment.
 - Version config file. This will help manage breaking changes in ldap2pg.
+- Fix default value for `allow_missing_attributes`.
 
 
 # ldap2pg 5.5

--- a/ldap2pg/validators.py
+++ b/ldap2pg/validators.py
@@ -46,9 +46,6 @@ def ldapquery(value, format_fields=None):
     # cases. Also, join attributes as predefined this way.
     strlist_alias(query, 'attributes', 'attribute')
 
-    strlist_alias(query, 'allow_missing_attributes', 'allow_missing_attribute')
-    query.setdefault('allow_missing_attributes', ['member'])
-
     alias(query, 'joins', 'join')
     query.setdefault('joins', {})
 
@@ -71,13 +68,19 @@ def ldapquery(value, format_fields=None):
         join_attrs = join.setdefault('attributes', [])
         join_attrs.append(field.attribute)
         join.setdefault(
-            'allow_missing_attributes', query['allow_missing_attributes'])
+            'allow_missing_attributes',
+            query.get('allow_missing_attributes', []))
         query['joins'][field.var] = ldapquery(join, [])
 
     if not attrs:
         fmt = "No attributes are used from LDAP query %(base)s"
         raise ValueError(fmt % value)
     query['attributes'] = list(attrs)
+
+    strlist_alias(query, 'allow_missing_attributes', 'allow_missing_attribute')
+    empty_attrs = query.setdefault('allow_missing_attributes', [])
+    if 'member' in attrs:
+        empty_attrs.append('member')
 
     # Post process joins.
     for key, join in query['joins'].copy().items():

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -213,7 +213,7 @@ def test_process_ldapquery_attributes():
     assert ['cn'] == v['attributes']
     assert 'attribute' not in v
     assert 'ignore' == v['on_unexpected_dn']
-    assert ['member'] == v['allow_missing_attributes']
+    assert not v['allow_missing_attributes']
 
     with pytest.raises(ValueError):
         ldapquery(dict(raw, scope='unkqdsfq'))


### PR DESCRIPTION
Avoid triggering warning for search without member.