### PR TITLE
Protect static rules from LDAP search

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 - Apply `LDAPCONF` `LDAPRC` from environment.
 - Version config file. This will help manage breaking changes in ldap2pg.
 - Fix default value for `allow_missing_attributes`.
+- Protect static rules mixed in dynamics rules instead of rejecting config.
 
 
 # ldap2pg 5.5

--- a/ldap2pg.yml
+++ b/ldap2pg.yml
@@ -168,11 +168,11 @@ sync_map:
 - description: "Query LDAP to create readers."
   ldap:
     base: ou=groups,dc=ldap,dc=ldap2pg,dc=docker
-    filter: |
+    filter: "
       (&
         (cn=bi)
         (objectClass=*)
-      )
+      )"
   role:
     name: '{member.cn}'
     options: LOGIN

--- a/ldap2pg/privilege.py
+++ b/ldap2pg/privilege.py
@@ -240,6 +240,13 @@ class GrantRule(object):
             map_.update(lst.attributes_map)
         return map_
 
+    @property
+    def is_dynamic(self):
+        return len(self.all_fields) > 0
+
+    def __eq__(self, other):
+        return self.as_dict() == other.as_dict()
+
     def __repr__(self):
         return '<%s %s on [%s].[%s] to [%s]>' % (
             self.__class__.__name__,
@@ -248,6 +255,10 @@ class GrantRule(object):
             self.schemas,
             self.roles,
         )
+
+    def copy(self, **kw):
+        kw = dict(self.as_dict(), **kw)
+        return self.__class__(**kw)
 
     def generate(self, vars_):
         privilege = next(self.privilege.expand(vars_))

--- a/ldap2pg/role.py
+++ b/ldap2pg/role.py
@@ -445,8 +445,15 @@ class RoleRule(object):
             self.comment, self.members, self.names, self.parents,
         )
 
+    def __eq__(self, other):
+        return hasattr(other, 'as_dict') and self.as_dict() == other.as_dict()
+
     def __repr__(self):
         return '<%s %s>' % (self.__class__.__name__, self.names)
+
+    @property
+    def is_dynamic(self):
+        return 0 != len(self.all_fields)
 
     @property
     def attributes_map(self):
@@ -454,6 +461,10 @@ class RoleRule(object):
         for lst in self.comment, self.members, self.names, self.parents:
             map_.update(lst.attributes_map)
         return map_
+
+    def copy(self, **kw):
+        kw = dict(self.as_dict(), **kw)
+        return self.__class__(**kw)
 
     def generate(self, vars_):
         names = self.names.expand(vars_)

--- a/ldap2pg/validators.py
+++ b/ldap2pg/validators.py
@@ -277,10 +277,6 @@ def mapping(value, **kw):
     if 'ldap' in value:
         roles = value.get('roles', [])
         grants = value.get('grant', [])
-        if any([r.names.has_static for r in roles]):
-            raise ValueError("Mixing static role with LDAP query may hide it.")
-        if any([r.roles.has_static for r in grants]):
-            raise ValueError("Mixing static role with LDAP query may hide it.")
         format_fields = set(
             iterchain(*[r.all_fields for r in roles + grants])
         )

--- a/ldap2pg/validators.py
+++ b/ldap2pg/validators.py
@@ -40,7 +40,7 @@ def ldapquery(value, format_fields=None):
     query = dict(default_ldap_query, **value)
     query['scope'] = parse_scope(query['scope'])
     if 'filter' in query:
-        query['filter'] = query['filter'].rstrip('\r\n')
+        query['filter'] = query['filter'].strip(' \r\n')
 
     # Accept manual attributes, for legacy. Attribute inference should in all
     # cases. Also, join attributes as predefined this way.

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -120,32 +120,6 @@ def test_process_syncmap_bad():
             syncmap(raw)
 
 
-def test_mapping_refuse_static_rules_when_ldap():
-    from ldap2pg.validators import mapping
-
-    raw = dict(
-        ldap=dict(base="toto"),
-        roles=["{cn}"],
-    )
-
-    assert mapping(raw.copy())
-
-    raw['roles'].append('static')
-    with pytest.raises(ValueError):
-        mapping(raw)
-
-    raw = dict(
-        ldap=dict(base="toto"),
-        grant=dict(roles=["{cn}"], privilege="ro"),
-    )
-
-    assert mapping(raw.copy())
-
-    raw['grant']['roles'].append('static')
-    with pytest.raises(ValueError):
-        mapping(raw)
-
-
 def test_process_mapping_grant():
     from ldap2pg.validators import mapping
 


### PR DESCRIPTION
See #356 

Hi @frafra, here is a fix that both accepts old config while still workaround unexpected behaviour from mixing static and dynamic rules.

What do you think of this ?

``` console
$ cat my-ldap2pg.yml 
sync_map:
- ldap:
    base: ou=groups,dc=ldap,dc=ldap2pg,dc=docker
    filter: "(cn=dba)"
  roles:
  - ldap_roles  # static rule attached to an ldap search!
  - name: '{member.cn}'
    parent: [ldap_roles]
$ ldap2pg -c my-ldap2pg.yml -v                                                                                                                                                                                                          
[ldap2pg.config        INFO] Starting ldap2pg 5.5.                                                                  
[ldap2pg.config       DEBUG] Trying my-ldap2pg.yml.  
...                                                                                                                                                                               
[ldap2pg.config       DEBUG] Extracted static role rule <RoleRule [ldap_roles]>.
...
```