### PR TITLE
Fix custom query for roles_blacklist_query

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 
 # Unreleased
 
+- Fix custom SQL query for `roles_blacklist_query`.
 - Build RHEL 8 package with Rockylinux 8
 
 

--- a/ldap2pg/inspector.py
+++ b/ldap2pg/inspector.py
@@ -223,7 +223,8 @@ class PostgresInspector(object):
         return databases, pgallroles, pgmanagedroles
 
     def fetch_roles_blacklist(self):
-        return self.fetch(self.psql, 'roles_blacklist_query', self.row1)
+        with self.psql() as psql:
+            return self.fetch(psql, 'roles_blacklist_query', self.row1)
 
     def fetch_schemas(self, databases, managedroles=None):
         # Fetch schemas and owners. This is required to trigger ACL inspection.

--- a/tests/func/ldap2pg.full.yml
+++ b/tests/func/ldap2pg.full.yml
@@ -29,6 +29,13 @@ postgres:
       ON owners.rolname = 'owners' AND owners.oid = ms.roleid
     ORDER BY 1;
 
+  roles_blacklist_query: |
+    VALUES
+    ('postgres'),
+    ('pg_*'),
+    ('rds_*')
+    ;
+
 
 privileges:
   ro:


### PR DESCRIPTION
Fixes:

    Inspecting roles in Postgres cluster...
    Unhandled error:
    Traceback (most recent call last):
      File "/usr/local/lib/python3.9/dist-packages/ldap2pg/script.py", line 37, in main
        exit(synchronize(config))
      File "/usr/local/lib/python3.9/dist-packages/ldap2pg/script.py", line 130, in synchronize
        count = manager.sync(syncmap=config['sync_map'])
      File "/usr/local/lib/python3.9/dist-packages/ldap2pg/manager.py", line 278, in sync
        self.inspector.roles_blacklist = self.inspector.fetch_roles_blacklist()
      File "/usr/local/lib/python3.9/dist-packages/ldap2pg/inspector.py", line 226, in fetch_roles_blacklist
        return self.fetch(self.psql, 'roles_blacklist_query', self.row1)
      File "/usr/local/lib/python3.9/dist-packages/ldap2pg/inspector.py", line 188, in fetch
        rows = list(self.timer.time_iter(rows))
      File "/usr/local/lib/python3.9/dist-packages/ldap2pg/utils.py", line 185, in time_iter
        item = next(iterator)
      File "/usr/local/lib/python3.9/dist-packages/ldap2pg/inspector.py", line 58, in row1
        for row in handle_decoding_error(rows):
      File "/usr/local/lib/python3.9/dist-packages/ldap2pg/inspector.py", line 324, in handle_decoding_error
        for item in iterator:
    TypeError: 'PSQLSession' object is not iterable

Closes: #399 