### PR TITLE
introduce concat in order to merge string in defacl query

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 # ldap2pg 5.9
 - Add datetime to starting message
 - Add datetime to each logging operation
+- Adapt defacl query in order to enhance compatability 
 
 # ldap2pg 5.8
 

--- a/ldap2pg/defaults.py
+++ b/ldap2pg/defaults.py
@@ -40,7 +40,7 @@ shared_queries = dict(
       FROM pg_catalog.pg_default_acl
     )
     SELECT
-      priv || '_on_' || objtype AS key,
+      CONCAT(priv, '_on_', objtype) AS key,
       nspname,
       COALESCE(rolname, 'public') AS rolname,
       TRUE AS full,


### PR DESCRIPTION
Running ldap2pg with Postgres 15 introduced the following error:

```
File /usr/local/lib/python3.9/dist-packages/ldap2pg/script.py, line 133, in synchronize  
    count = manager.sync(syncmap=config['sync_map'])
  File /usr/local/lib/python3.9/dist-packages/ldap2pg/manager.py, line 331, in sync
    pgacl = self.inspector.fetch_grants(schemas, pgmanagedroles)
  File /usr/local/lib/python3.9/dist-packages/ldap2pg/inspector.py, line 266, in fetch_grants
    rows = self.fetch_shared_query(
  File /usr/local/lib/python3.9/dist-packages/ldap2pg/inspector.py, line 292, in fetch_shared_query
    rows = list(conn.query(None, self.shared_queries[name]))
  File /usr/local/lib/python3.9/dist-packages/ldap2pg/psql.py, line 122, in query
    cur.execute(sql, *args)
  File /usr/local/lib/python3.9/dist-packages/ldap2pg/psql.py, line 168, in execute
    return super(FactoryCursor, self).execute(query, *a, **kw)
psycopg2.errors.AmbiguousFunction: operator is not unique: text || char
LINE 12:   priv || '_on_' || objtype AS key,                          ^
HINT:  Could not choose a best candidate operator. You might need to add explicit type casts.
Please file an issue at https://github.com/dalibo/ldap2pg/issues with full log.
```

In Order to fix this I adapted the acl default query to utilize the concat function instead of ||