### PR TITLE
fix for pg16.

### DIFF
--- a/cmd/ldap2pg/ldap2pg.go
+++ b/cmd/ldap2pg/ldap2pg.go
@@ -119,7 +119,7 @@ func ldap2pg(ctx context.Context) (err error) {
 		slog.Warn("Dry run. Postgres instance will be untouched.")
 	}
 
-	queries := role.Diff(instance.AllRoles, instance.ManagedRoles, wantedRoles, instance.Me, instance.FallbackOwner, &instance.Databases)
+	queries := role.Diff(instance.AllRoles, instance.ManagedRoles, wantedRoles, instance.Me, instance.FallbackOwner, &instance.Databases, instance.ServerVersionNum)
 	queries = postgres.GroupByDatabase(instance.Databases, instance.DefaultDatabase, queries)
 	stageCount, err := postgres.Apply(ctx, &controller.PostgresWatch, queries, controller.Real)
 	if err != nil {

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -19,7 +19,7 @@ You can mix static rules and dynamic rules in the same file.
 ## Running unprivileged
 
 ldap2pg is designed to run unprivileged.
-Synchronization user needs `CREATEROLE` option to manage other unprivileged roles.
+Synchronization user needs `CREATEROLE` option and ADMIN OPTION to manage other unprivileged roles.
 `CREATEDB` options allows synchronization user to managed database owners.
 
 

--- a/internal/inspect/stage0.go
+++ b/internal/inspect/stage0.go
@@ -23,6 +23,7 @@ type Instance struct {
 	ManagedRoles     role.Map
 	Me               role.Role
 	RolesBlacklist   lists.Blacklist
+	ServerVersionNum int
 }
 
 func Stage0(ctx context.Context, pc Config) (instance Instance, err error) {
@@ -72,9 +73,8 @@ func (instance *Instance) InspectSession(ctx context.Context, fallbackOwner stri
 		panic("No data returned.")
 	}
 	var clusterName, serverVersion string
-	var serverVersionNum int
 	err = rows.Scan(
-		&serverVersion, &serverVersionNum,
+		&serverVersion, &instance.ServerVersionNum,
 		&clusterName, &instance.DefaultDatabase,
 		&instance.Me.Name, &instance.Me.Options.Super,
 	)

--- a/internal/role/diff.go
+++ b/internal/role/diff.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-func Diff(all, managed, wanted Map, me Role, fallbackOwner string, databases *postgres.DBMap) <-chan postgres.SyncQuery {
+func Diff(all, managed, wanted Map, me Role, fallbackOwner string, databases *postgres.DBMap, serverVersionNum int) <-chan postgres.SyncQuery {
 	ch := make(chan postgres.SyncQuery)
 	go func() {
 		defer close(ch)
@@ -17,9 +17,9 @@ func Diff(all, managed, wanted Map, me Role, fallbackOwner string, databases *po
 				if _, ok := managed[name]; !ok {
 					slog.Warn("Reusing unmanaged role. Ensure managed_roles_query returns all wanted roles.", "role", name)
 				}
-				sendQueries(other.Alter(role), ch)
+				sendQueries(other.Alter(role, serverVersionNum), ch)
 			} else {
-				sendQueries(role.Create(me.Options.Super), ch)
+				sendQueries(role.Create(me.Options.Super, serverVersionNum), ch)
 			}
 		}
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -74,6 +74,12 @@ class PSQL(object):
             c[kv[0]] = kv[1]
         return c
 
+    def version(self):
+        # Get server_version_num.
+        return self.select1(
+                "SELECT setting::BIGINT FROM pg_settings WHERE name = 'server_version_num';"
+        )
+
 
 @pytest.fixture(scope='module', autouse=True)
 def pgenv(request):
@@ -130,6 +136,10 @@ def resetpostgres():
     Command('test/fixtures/reset.sh')()
     Command('test/fixtures/nominal.sh')()
     Command('test/fixtures/extra.sh')()
+
+    version = int(next(iter(PSQL().version())))
+    if version >= 160000:
+        Command('test/fixtures/setup_for_pg16.sh')()
 
 
 def lazy_write(attr, data):


### PR DESCRIPTION
Hi,

CREATEROLE privileges are restricted in PG16, so ldap2pg user could not grant ADMIN OPTION to himself when ldap2pg is executed by non-superuser.
Moreover,  non-superuser  needs to INHERIT OPTION to modify default privileges.

I send this PR to resolve this issue.  Thoughts?