### PR TITLE
Throw error on unknown ACL

### DIFF
--- a/cmd/render-doc/main.go
+++ b/cmd/render-doc/main.go
@@ -41,12 +41,12 @@ func main() {
 
 	data := struct {
 		Groups   map[string][]interface{}
-		Refs     map[string]map[string]string
-		Defaults map[string]map[string]string
+		Refs     map[string]map[string]interface{}
+		Defaults map[string]map[string]interface{}
 	}{
 		Groups:   make(map[string][]interface{}),
-		Refs:     make(map[string]map[string]string),
-		Defaults: make(map[string]map[string]string),
+		Refs:     make(map[string]map[string]interface{}),
+		Defaults: make(map[string]map[string]interface{}),
 	}
 
 	for key, items := range config.BuiltinsProfiles {
@@ -57,9 +57,9 @@ func main() {
 			data.Groups[key] = l
 		default:
 			if strings.HasPrefix(key, "__default") {
-				data.Defaults[key] = item.(map[string]string)
+				data.Defaults[key] = item.(map[string]interface{})
 			} else {
-				data.Refs[key] = item.(map[string]string)
+				data.Refs[key] = item.(map[string]interface{})
 			}
 		}
 	}

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -1,3 +1,4 @@
+<!-- GENERATED FROM docs/builtins.md.tmpl FOR v6.1.0-alpha0 -->
 <!--*- markdown -*-->
 
 <h1>Builtins Privileges</h1>
@@ -68,6 +69,7 @@ Here is the list of builtin ACL.
 For effective privileges:
 
 - `DATABASE`: privilege on database like `CONNECT`, `CREATE`, etc.
+- `SCHEMA`: manage `USAGE` and `CREATE` on schema.
 - `LANGUAGE`: manage `USAGE` on procedural languages.
 - `ALL FUNCTIONS IN SCHEMA`: manage `EXECUTE` on all functions per schema.
 - `ALL SEQUENCES IN SCHEMA`: like above but for sequences.

--- a/docs/builtins.md.tmpl
+++ b/docs/builtins.md.tmpl
@@ -68,6 +68,7 @@ Here is the list of builtin ACL.
 For effective privileges:
 
 - `DATABASE`: privilege on database like `CONNECT`, `CREATE`, etc.
+- `SCHEMA`: manage `USAGE` and `CREATE` on schema.
 - `LANGUAGE`: manage `USAGE` on procedural languages.
 - `ALL FUNCTIONS IN SCHEMA`: manage `EXECUTE` on all functions per schema.
 - `ALL SEQUENCES IN SCHEMA`: like above but for sequences.


### PR DESCRIPTION
We have added a test to check that unknown ACLs
are not allowed in the configuration.
Yaml have been adapted to reflect this change in
privilege_test.go