### PR TITLE
Adding the possibility to put conf file inside the directory /etc/lda…

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -18,6 +18,7 @@ ldap2pg searches for configuration file in the following order :
 1. `ldap2pg.yml` in current working directory.
 2. `~/.config/ldap2pg.yml`.
 3. `/etc/ldap2pg.yml`.
+4. `/etc/ldap2pg/ldap2pg.yml`.
 
 If `LDAP2PG_CONFIG` or `--config` is set,
 ldap2pg skips searching the standard file locations.

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -41,6 +41,8 @@ func FindConfigFile(userValue string) string {
 		path.Join(home, "/.config/ldap2pg.yaml"),
 		"/etc/ldap2pg.yml",
 		"/etc/ldap2pg.yaml",
+		"/etc/ldap2pg/ldap2pg.yml",
+		"/etc/ldap2pg/ldap2pg.yaml",
 	}
 	return FindFile(userValue, candidates)
 }


### PR DESCRIPTION
Hello,

As a pgbackrest's enduser, I thought why not to put the configuration file here `/etc/ldap2pg/ldap2pg.y(a)ml` and at my big surprise, it didn't work.

So here is a commit to implement this tiny feature.

Robin,