### PR TITLE
Delete built-in default privileges for grant EXECUTE on functions to …

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ Here is a highlight of changes in each versions. If you need further details,
 follow [merged Pull request
 pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
+# ldap2pg 6.3
+
+- Fix drop all builtin privileges for the role `PUBLIC` on the first execution.
+
 # ldap2pg 6.2
 
 - Postgres 17 support.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@ Here is a highlight of changes in each versions. If you need further details,
 follow [merged Pull request
 pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
-# ldap2pg 6.3
+# Unreleased
 
 - Fix drop all builtin privileges for the role `PUBLIC` on the first execution.
 

--- a/internal/privilege/sql/global-default.sql
+++ b/internal/privilege/sql/global-default.sql
@@ -28,6 +28,19 @@ grants AS (
 
      UNION ALL
 
+     SELECT 0::oid AS nsp,
+            pg_roles.oid AS owner,
+            'FUNCTIONS' AS object,
+            0::oid AS grantee,
+            'EXECUTE' AS priv
+     FROM pg_catalog.pg_roles
+     LEFT OUTER JOIN pg_catalog.pg_default_acl
+          ON defaclrole = pg_roles.oid
+          AND defaclnamespace = 0
+     WHERE defaclnamespace IS NULL
+
+     UNION ALL
+
     SELECT defaclnamespace AS nsp,
            defaclrole AS owner,
            CASE defaclobjtype


### PR DESCRIPTION
Closes: #674 

With this fix, `ldap2pg` drop builtin privileges for the `PUBLIC` role on the first execution.



