### PR TITLE
feat: update publish-deb to support noble

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ publish-deb:
 	$(MAKE) dist/$(PKGBASE)_buster.changes
 	$(MAKE) dist/$(PKGBASE)_stretch.changes
 	$(MAKE) dist/$(PKGBASE)_jammy.changes
+	$(MAKE) dist/$(PKGBASE)_noble.changes
 	@if expr match "$(VERSION)" ".*[a-z]\+" >/dev/null; then echo 'Refusing to publish prerelease $(VERSION) in APT repository.'; false ; fi
 	dput labs dist/*.changes
 


### PR DESCRIPTION
Regarding https://github.com/dalibo/ldap2pg/issues/731

Manually installed in a noble virtual machine using the Jammy repository version and worked flawlessly, hence I believe is just a change to actually push it into the noble apt repository.