### PR TITLE
Fix empty filter in configuration file

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@ pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Am
 - Bump PostgreSQL developpement version to 18
 - Fix duplicate CREATE ROLE.
 - Resolve ~ in path.
+- Fix empty filter in configuration file leading to panic.
 
 
 # ldap2pg 6.5.1

--- a/internal/config/normalizers.go
+++ b/internal/config/normalizers.go
@@ -189,6 +189,12 @@ func NormalizeCommonLdapSearch(yaml any) (search map[string]any, err error) {
 	if !ok {
 		return nil, fmt.Errorf("bad type: %T", yaml)
 	}
+
+	// remove filter if empty to avoid panic
+	if val, exists := yamlMap["filter"]; exists && val == nil {
+		delete(yamlMap, "filter")
+	}
+
 	maps.Copy(search, yamlMap)
 	search["filter"] = ldap.CleanFilter(search["filter"].(string))
 	return

--- a/internal/config/normalizers_test.go
+++ b/internal/config/normalizers_test.go
@@ -69,3 +69,27 @@ func TestNormalizeConfig(t *testing.T) {
 	syncMap := config["rules"].([]any)
 	r.Len(syncMap, 2)
 }
+
+func TestNormalizeCommonLdapSearch(t *testing.T) {
+	r := require.New(t)
+	rawYaml := dedent.Dedent(`
+    base: cn=users,dc=bridoulou,dc=fr
+    filter:
+	`)
+	var raw any
+	yaml.Unmarshal([]byte(rawYaml), &raw) //nolint:errcheck
+
+	search, err := config.NormalizeCommonLdapSearch(raw)
+	r.Nil(err)
+	r.Equal(search["filter"], "(objectClass=*)")
+
+	rawYaml = dedent.Dedent(`
+    base: cn=users,dc=bridoulou,dc=fr
+    filter: (cn=test)
+	`)
+	yaml.Unmarshal([]byte(rawYaml), &raw) //nolint:errcheck
+
+	search, err = config.NormalizeCommonLdapSearch(raw)
+	r.Nil(err)
+	r.Equal(search["filter"], "(cn=test)")
+}


### PR DESCRIPTION
Fixes: #757 
If filter is empty in the configuration file,
replace it with the default value (objectClass=*)
to avoid panic.