### PR TITLE
Fix subsearches error in yaml

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,11 @@ Here is a highlight of changes in each versions. If you need further details,
 follow [merged Pull request
 pages](https://github.com/dalibo/ldap2pg/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Amerged).
 
+# Unreleased
+
+- Fix subsearches error in yaml.
+
+
 # ldap2pg 6.6.0
 
 - Fix memory usage value.

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -43,12 +43,28 @@ func TestStrictYaml(t *testing.T) {
 	  databases_query: [nominal]
 	ldap:
 	  password: "secret"
+	rules:
+	- description: "Readonly"
+	  ldapsearch:
+	    base: "ou=groups,o=test"
+	    scope: one
+	    filter: "(&(objectClass=groupOfNames)(cn=admin)(member=*))"
+	    joins:
+	      member:
+	        scope: base
+	        filter: "(|(objectClass=inetOrgPerson)(objectClass=person))"
+	  roles:
+	    - name: "{member.uid}"
 	`)
 	var value map[string]any
-	yaml.Unmarshal([]byte(rawYaml), &value) //nolint:errcheck
+	err := yaml.Unmarshal([]byte(rawYaml), &value)
+	r.Nil(err)
+
+	value, err = config.NormalizeConfigRoot(value)
+	r.Nil(err)
 
 	c := config.New()
-	err := c.DecodeYaml(value)
+	err = c.DecodeYaml(value)
 	r.EqualError(err, "invalid configuration file\n'ldap' has invalid keys: password\n'postgres' has invalid keys: uri")
 	errs := errorlist.Unwrap(err)
 	r.Len(errs, 3)

--- a/internal/ldap/search.go
+++ b/internal/ldap/search.go
@@ -10,7 +10,7 @@ type Search struct {
 	Scope       Scope
 	Filter      string
 	Attributes  []string
-	Subsearches map[string]Subsearch `mapstructure:"joins"`
+	Subsearches map[string]Subsearch
 }
 
 func (s Search) SubsearchAttribute() string {


### PR DESCRIPTION
Fixes #789 
Since the configuration file is normalised before
decoding, joins are already replaced by subsearches.